### PR TITLE
Enable JMX statistics for all collections

### DIFF
--- a/_healthcheck/solrconfig.xml
+++ b/_healthcheck/solrconfig.xml
@@ -12,6 +12,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/argo_b/solrconfig.xml
+++ b/argo_b/solrconfig.xml
@@ -22,6 +22,8 @@
     </updateLog>
   </updateHandler>
   
+  <jmx />
+  
   <!-- Used by reports via queries that pass qt=search -->
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these

--- a/argo_dev/solrconfig.xml
+++ b/argo_dev/solrconfig.xml
@@ -22,6 +22,8 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request

--- a/avalon/solrconfig.xml
+++ b/avalon/solrconfig.xml
@@ -16,7 +16,7 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
   </updateHandler>
-
+  <jmx />
 
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these

--- a/bassi/solrconfig.xml
+++ b/bassi/solrconfig.xml
@@ -36,7 +36,7 @@
       <str name="dir">${solr.core0.data.dir:}</str>
     </updateLog>
   </updateHandler>
-
+  <jmx />
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/dig_hcrc_prod/solrconfig.xml
+++ b/dig_hcrc_prod/solrconfig.xml
@@ -107,7 +107,7 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
     </updateHandler>
-    
+    <jmx />
     <requestHandler name="/get" class="solr.RealTimeGetHandler">
       <lst name="defaults">
         <str name="omitHeader">true</str>

--- a/dig_hcrc_test/solrconfig.xml
+++ b/dig_hcrc_test/solrconfig.xml
@@ -107,7 +107,7 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
     </updateHandler>
-    
+    <jmx />
     <requestHandler name="/get" class="solr.RealTimeGetHandler">
       <lst name="defaults">
         <str name="omitHeader">true</str>

--- a/dig_kircher_prod/solrconfig.xml
+++ b/dig_kircher_prod/solrconfig.xml
@@ -71,7 +71,7 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
     </updateHandler>
-    
+    <jmx />
     <requestHandler name="/get" class="solr.RealTimeGetHandler">
       <lst name="defaults">
         <str name="omitHeader">true</str>

--- a/dig_kircher_test/solrconfig.xml
+++ b/dig_kircher_test/solrconfig.xml
@@ -71,7 +71,7 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
     </updateHandler>
-    
+    <jmx />
     <requestHandler name="/get" class="solr.RealTimeGetHandler">
       <lst name="defaults">
         <str name="omitHeader">true</str>

--- a/dig_opera/solrconfig.xml
+++ b/dig_opera/solrconfig.xml
@@ -73,7 +73,7 @@
       <str name="dir">${solr.core1.data.dir:}</str>
     </updateLog>
   </updateHandler>
-
+  <jmx />
 <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />
 
   <!-- realtime get handler, guaranteed to return the latest stored fields 

--- a/dig_opera_prod/solrconfig.xml
+++ b/dig_opera_prod/solrconfig.xml
@@ -71,6 +71,9 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
     </updateHandler>
+
+    <jmx />
+
     
     
     <requestHandler name="/get" class="solr.RealTimeGetHandler">

--- a/dig_opera_test/solrconfig.xml
+++ b/dig_opera_test/solrconfig.xml
@@ -70,6 +70,9 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
     </updateHandler>
+
+    <jmx />
+
     
     
     <requestHandler name="/get" class="solr.RealTimeGetHandler">

--- a/dms-dev/solrconfig.xml
+++ b/dms-dev/solrconfig.xml
@@ -31,6 +31,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/dms-prod/solrconfig.xml
+++ b/dms-prod/solrconfig.xml
@@ -31,6 +31,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/eems-dev/solrconfig.xml
+++ b/eems-dev/solrconfig.xml
@@ -15,6 +15,9 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
   </updateHandler>
+
+  <jmx />
+
   
   <dataDir>${solr.data.dir:}</dataDir>
 

--- a/exhibit_demo_index/solrconfig.xml
+++ b/exhibit_demo_index/solrconfig.xml
@@ -16,6 +16,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <dataDir>${solr.data.dir:}</dataDir>
 
   <requestHandler name="search" class="solr.SearchHandler" default="true">

--- a/exhibits/solrconfig.xml
+++ b/exhibits/solrconfig.xml
@@ -15,6 +15,9 @@
       <str name="dir">${solr.core0.data.dir:}</str>
     </updateLog>
   </updateHandler>
+
+  <jmx />
+
   
   <dataDir>${solr.data.dir:}</dataDir>
 

--- a/exhibits_dev/solrconfig.xml
+++ b/exhibits_dev/solrconfig.xml
@@ -16,6 +16,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- solr lib dirs -->
   <lib dir="../lib/contrib/analysis-extras/lib" />
   <lib dir="../lib/contrib/analysis-extras/lucene-libs" />

--- a/exhibits_prod_africa/solrconfig.xml
+++ b/exhibits_prod_africa/solrconfig.xml
@@ -15,6 +15,9 @@
       <str name="dir">${solr.core0.data.dir:}</str>
     </updateLog>
   </updateHandler>
+
+  <jmx />
+
   
   <dataDir>${solr.data.dir:}</dataDir>
 

--- a/exhibits_prod_default/solrconfig.xml
+++ b/exhibits_prod_default/solrconfig.xml
@@ -15,6 +15,9 @@
       <str name="dir">${solr.core0.data.dir:}</str>
     </updateLog>
   </updateHandler>
+
+  <jmx />
+
   
   <dataDir>${solr.data.dir:}</dataDir>
 

--- a/exhibits_prod_fitch/solrconfig.xml
+++ b/exhibits_prod_fitch/solrconfig.xml
@@ -15,6 +15,9 @@
       <str name="dir">${solr.core0.data.dir:}</str>
     </updateLog>
   </updateHandler>
+
+  <jmx />
+
   
   <dataDir>${solr.data.dir:}</dataDir>
 

--- a/exhibits_prod_mss/solrconfig.xml
+++ b/exhibits_prod_mss/solrconfig.xml
@@ -15,6 +15,9 @@
       <str name="dir">${solr.core0.data.dir:}</str>
     </updateLog>
   </updateHandler>
+
+  <jmx />
+
   
   <dataDir>${solr.data.dir:}</dataDir>
 

--- a/exhibits_prod_walters/solrconfig.xml
+++ b/exhibits_prod_walters/solrconfig.xml
@@ -15,6 +15,9 @@
       <str name="dir">${solr.core0.data.dir:}</str>
     </updateLog>
   </updateHandler>
+
+  <jmx />
+
   
   <dataDir>${solr.data.dir:}</dataDir>
 

--- a/exhibits_sandbox_dev/solrconfig.xml
+++ b/exhibits_sandbox_dev/solrconfig.xml
@@ -16,6 +16,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <dataDir>${solr.data.dir:}</dataDir>
 
   <requestHandler name="search" class="solr.SearchHandler" default="true">

--- a/frda-stage/solrconfig.xml
+++ b/frda-stage/solrconfig.xml
@@ -36,6 +36,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <query>
     <maxBooleanClauses>1024</maxBooleanClauses>
     <filterCache class="solr.FastLRUCache" size="512" initialSize="512" autowarmCount="0"/>

--- a/frda/solrconfig.xml
+++ b/frda/solrconfig.xml
@@ -36,6 +36,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <query>
     <maxBooleanClauses>1024</maxBooleanClauses>
     <filterCache class="solr.FastLRUCache" size="512" initialSize="512" autowarmCount="0"/>

--- a/kircher/solrconfig.xml
+++ b/kircher/solrconfig.xml
@@ -72,6 +72,9 @@
       <str name="dir">${solr.data.dir:}</str>
     </updateLog>
     </updateHandler>
+
+    <jmx />
+
     
     <requestHandler name="/get" class="solr.RealTimeGetHandler">
       <lst name="defaults">

--- a/kurma-app-dev/solrconfig.xml
+++ b/kurma-app-dev/solrconfig.xml
@@ -40,6 +40,9 @@
     </autoCommit>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/kurma-app-test/solrconfig.xml
+++ b/kurma-app-test/solrconfig.xml
@@ -40,6 +40,9 @@
     </autoCommit>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/kurma-earthworks-dev/solrconfig.xml
+++ b/kurma-earthworks-dev/solrconfig.xml
@@ -40,6 +40,9 @@
     </autoCommit>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/kurma-earthworks-prod/solrconfig.xml
+++ b/kurma-earthworks-prod/solrconfig.xml
@@ -40,6 +40,9 @@
     </autoCommit>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/kurma-earthworks-stage/solrconfig.xml
+++ b/kurma-earthworks-stage/solrconfig.xml
@@ -40,6 +40,9 @@
     </autoCommit>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/marc-profiler/solrconfig.xml
+++ b/marc-profiler/solrconfig.xml
@@ -33,6 +33,9 @@
     </autoCommit>
   </updateHandler>
 
+  <jmx />
+
+
   <query>
     <maxBooleanClauses>1024</maxBooleanClauses>
     <filterCache class="solr.FastLRUCache" size="512" initialSize="512" autowarmCount="0"/>

--- a/mods_profiler/solrconfig.xml
+++ b/mods_profiler/solrconfig.xml
@@ -39,6 +39,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <query>
     <maxBooleanClauses>1024</maxBooleanClauses>
     <filterCache class="solr.FastLRUCache" size="512" initialSize="512" autowarmCount="0"/>

--- a/purl-dev/solrconfig.xml
+++ b/purl-dev/solrconfig.xml
@@ -33,6 +33,9 @@
 
   </updateHandler>
 
+  <jmx />
+
+
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request

--- a/purl-prod/solrconfig.xml
+++ b/purl-prod/solrconfig.xml
@@ -33,6 +33,9 @@
 
   </updateHandler>
 
+  <jmx />
+
+
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request

--- a/purl-stage/solrconfig.xml
+++ b/purl-stage/solrconfig.xml
@@ -33,6 +33,9 @@
 
   </updateHandler>
 
+  <jmx />
+
+
   <requestHandler name="search" class="solr.SearchHandler" default="true">
     <!-- default values for query parameters can be specified, these
          will be overridden by parameters in the request

--- a/revs-dev/solrconfig.xml
+++ b/revs-dev/solrconfig.xml
@@ -37,6 +37,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/revs-lib/solrconfig.xml
+++ b/revs-lib/solrconfig.xml
@@ -37,6 +37,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/revs-prod-a/solrconfig.xml
+++ b/revs-prod-a/solrconfig.xml
@@ -37,6 +37,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/revs-prod-b/solrconfig.xml
+++ b/revs-prod-b/solrconfig.xml
@@ -37,6 +37,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/revs-prod/solrconfig.xml
+++ b/revs-prod/solrconfig.xml
@@ -37,6 +37,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/revs-stage/solrconfig.xml
+++ b/revs-stage/solrconfig.xml
@@ -37,6 +37,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/revs/solrconfig.xml
+++ b/revs/solrconfig.xml
@@ -37,6 +37,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <!-- realtime get handler, guaranteed to return the latest stored fields 
     of any document, without the need to commit or open a new searcher. The current 
     implementation relies on the updateLog feature being enabled. -->

--- a/sax_profiler/solrconfig.xml
+++ b/sax_profiler/solrconfig.xml
@@ -39,6 +39,9 @@
     </updateLog>
   </updateHandler>
 
+  <jmx />
+
+
   <query>
     <maxBooleanClauses>1024</maxBooleanClauses>
     <filterCache class="solr.FastLRUCache" size="512" initialSize="512" autowarmCount="0"/>

--- a/spec/cores/solrconfig_spec.rb
+++ b/spec/cores/solrconfig_spec.rb
@@ -21,6 +21,10 @@ describe "solrconfig.xml" do
     it "has admin handlers defined" do
       expect(subject.xpath('/config/requestHandler[@name="/admin/"]')).not_to be_empty
     end
+    
+    it "has jmx defined" do
+      expect(subject.xpath('/config/jmx')).not_to be_empty
+    end
   end
 
   solr_collections.each do |name|

--- a/sul-cms-dev/solrconfig.xml
+++ b/sul-cms-dev/solrconfig.xml
@@ -268,7 +268,7 @@
 
        For more details see http://wiki.apache.org/solr/SolrJmx
     -->
-  <!-- <jmx /> -->
+  <jmx />
   <!-- If you want to connect to a particular server, specify the
        agentId
     -->

--- a/sul-cms-prod/solrconfig.xml
+++ b/sul-cms-prod/solrconfig.xml
@@ -268,7 +268,7 @@
 
        For more details see http://wiki.apache.org/solr/SolrJmx
     -->
-  <!-- <jmx /> -->
+  <jmx />
   <!-- If you want to connect to a particular server, specify the
        agentId
     -->


### PR DESCRIPTION
JMX statistics will allow us to monitor the performance of solr collections:

https://wiki.apache.org/solr/SolrJmx
