### PR TITLE
Fixes failing tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ group :test do
   gem 'nokogiri'
   gem 'rake'
   gem 'rubocop'
-  gem 'solr_wrapper', '~> 0.8'
+  gem 'solr_wrapper', '~> 0.13'
   gem 'hurley'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,11 @@ GEM
   specs:
     ast (2.2.0)
     diff-lcs (1.2.5)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     hurley (0.2)
     mini_portile2 (2.0.0)
+    multipart-post (2.0.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     parser (2.3.0.3)
@@ -33,7 +36,8 @@ GEM
       unicode-display_width (~> 0.3)
     ruby-progressbar (1.7.5)
     rubyzip (1.2.0)
-    solr_wrapper (0.8.1)
+    solr_wrapper (0.13.1)
+      faraday
       ruby-progressbar
       rubyzip
     unicode-display_width (0.3.1)
@@ -47,7 +51,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop
-  solr_wrapper (~> 0.8)
+  solr_wrapper (~> 0.13)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5


### PR DESCRIPTION
All travis tests were failing with `404`s with previous version of `solr_wrapper` -  not sure if pinning this to `~0.13` is what we want though.