### PR TITLE
GeoBlacklight v1.0 Solr 6 core  for development

### DIFF
--- a/kurma-earthworks-v1-dev/schema.xml
+++ b/kurma-earthworks-v1-dev/schema.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema name="geoblacklight-schema" version="1.6">
+  <uniqueKey>layer_slug_s</uniqueKey>
+  <fields>
+    <field name="_version_" type="long"   stored="true" indexed="true"/>
+    <field name="timestamp" type="date"   stored="true" indexed="true" default="NOW"/>
+    <field name="layer_slug_s" type="string" stored="true" indexed="true" required="true"/>
+    <field name="geoblacklight_version" type="string" stored="true" indexed="true"/>
+    <field name="uuid"      type="string" stored="true" indexed="true"/><!-- deprecated -->
+
+    <!-- core generated fields -->
+    <field name="text" type="text_en" stored="false" indexed="true" multiValued="true"
+                       termVectors="true" termPositions="true" termOffsets="true" />
+
+    <!-- dynamic field with simple types by suffix -->
+    <dynamicField name="*_b"    type="boolean" stored="true"  indexed="true"/>
+    <dynamicField name="*_d"    type="double"  stored="true"  indexed="true"/>
+    <dynamicField name="*_dt"   type="date"    stored="true"  indexed="true"/>
+    <dynamicField name="*_f"    type="float"   stored="true"  indexed="true"/>
+    <dynamicField name="*_i"    type="int"     stored="true"  indexed="true"/>
+    <dynamicField name="*_im"   type="int"     stored="true"  indexed="true" multiValued="true" />
+    <dynamicField name="*_l"    type="long"    stored="true"  indexed="true"/>
+    <dynamicField name="*_s"    type="string"  stored="true"  indexed="true"/>
+    <dynamicField name="*_ss"   type="string"  stored="true"  indexed="false"/>
+    <dynamicField name="*_si"   type="string"  stored="false" indexed="true"/>
+    <dynamicField name="*_sim"  type="string"  stored="false" indexed="true" multiValued="true" />
+    <dynamicField name="*_sm"   type="string"  stored="true"  indexed="true" multiValued="true" />
+    <dynamicField name="*_url"  type="string"  stored="true"  indexed="false"/>
+    <dynamicField name="*_blob" type="binary"  stored="true"  indexed="false"/>
+
+    <!-- dynamic Text fields by suffix without storage -->
+    <dynamicField name="*_t"    type="text_en" stored="false"  indexed="true"
+                                termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tm"   type="text_en" stored="false"  indexed="true" multiValued="true"
+                                termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_ti"   type="text_en" stored="false" indexed="true"
+                                termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tmi"  type="text_en" stored="false" indexed="true" multiValued="true"
+                                termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_sort" type="text_sort" stored="false" indexed="true" multiValued="false"/>
+
+    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
+
+    <!-- Spatial field types:
+
+         Solr3:
+           <field name="my_pt">83.1,-117.312</field>
+             as (y,x)
+
+         Solr4:
+
+           <field name="my_bbox">-117.312 83.1 -115.39 84.31</field>
+             as (W S E N)
+
+           <field name="my_geom">ENVELOPE(-117.312, -115.39, 84.31, 83.1)</field>
+             as (W E N S)
+
+           <field name="my_jts">POLYGON((1 8, 1 9, 2 9, 2 8, 1 8))</field>
+             as WKT for point, linestring, polygon
+
+      -->
+    <dynamicField name="*_pt"   type="location"     stored="true" indexed="true"/>
+    <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/><!-- deprecated -->
+    <dynamicField name="*_geom" type="location_rpt" stored="true" indexed="true"/>
+    <!-- <dynamicField name="*_jts"  type="location_jts" stored="true" indexed="true"/> -->
+  </fields>
+
+  <types>
+    <fieldType name="string"  class="solr.StrField"  sortMissingLast="true" />
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
+
+    <fieldType name="int"    class="solr.TrieIntField"     precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="float"  class="solr.TrieFloatField"   precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="long"   class="solr.TrieLongField"    precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="double" class="solr.TrieDoubleField"  precisionStep="8" positionIncrementGap="0"/>
+
+    <!-- The format for this date field is of the form 1995-12-31T23:59:59Z.
+         The trailing "Z" designates UTC time and is mandatory.
+         A Trie based date field for faster date range queries and date faceting. -->
+    <fieldType name="date" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
+
+    <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
+    <fieldtype name="binary" class="solr.BinaryField"/>
+
+    <!-- A text field with defaults appropriate for English: it
+         tokenizes with StandardTokenizer, down cases, and
+         finally applies Porter's stemming. -->
+    <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.PorterStemFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- for alpha sorting as a single token -->
+    <fieldType name="text_sort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory" />
+        <filter class="solr.TrimFilterFactory" />
+        <filter class="solr.PatternReplaceFilterFactory" pattern="([^a-z0-9 ])" replacement="" replace="all"/>
+      </analyzer>
+    </fieldType>
+
+    <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
+      <analyzer>
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.StandardFilterFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+
+    <!-- Spatial field types -->
+    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_d"/>
+
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
+               distErrPct="0.025"
+               maxDistErr="0.000009"
+               distanceUnits="degrees"
+            />
+  </types>
+
+  <!-- for scoring formula -->
+  <copyField source="dct_spatial_sm"     dest="dct_spatial_tmi"     maxChars="10000"/>
+  <copyField source="dct_temporal_sm"    dest="dct_temporal_tmi"    maxChars="10000"/>
+  <copyField source="dc_creator_sm"      dest="dc_creator_tmi"      maxChars="1000"/>
+  <copyField source="dc_description_s"   dest="dc_description_ti"   maxChars="10000"/>
+  <copyField source="dc_format_s"        dest="dc_format_ti"        maxChars="100"/>
+  <copyField source="dc_identifier_s"    dest="dc_identifier_ti"    maxChars="100"/>
+  <copyField source="dc_publisher_s"     dest="dc_publisher_ti"     maxChars="1000"/>
+  <copyField source="dc_rights_s"        dest="dc_rights_ti"        maxChars="100"/>
+  <copyField source="dct_provenance_s"   dest="dct_provenance_ti"   maxChars="1000"/>
+  <copyField source="dc_subject_sm"      dest="dc_subject_tmi"      maxChars="10000"/>
+  <copyField source="dc_title_s"         dest="dc_title_ti"         maxChars="1000"/>
+  <copyField source="dct_isPartOf_sm"    dest="dct_isPartOf_tmi"    maxChars="1000"/>
+  <copyField source="layer_geom_type_s"  dest="layer_geom_type_ti"  maxChars="100"/>
+  <copyField source="layer_slug_s"       dest="layer_slug_ti"       maxChars="100"/>
+
+  <!-- core text search -->
+  <copyField source="*_ti"               dest="text" />
+  <copyField source="*_tmi"              dest="text" />
+
+  <!-- for sorting text fields -->
+  <copyField source="dct_provenance_s"   dest="dct_provenance_sort"/>
+  <copyField source="dc_publisher_s"     dest="dc_publisher_sort"/>
+  <copyField source="dc_title_s"         dest="dc_title_sort"/>
+
+</schema>

--- a/kurma-earthworks-v1-dev/solrconfig.xml
+++ b/kurma-earthworks-v1-dev/solrconfig.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<!--
+     For more details about configurations options that may appear in
+     this file, see http://wiki.apache.org/solr/SolrConfigXml.
+-->
+<config>
+  <luceneMatchVersion>6.1.0</luceneMatchVersion>
+  <dataDir>${solr.data.dir:}</dataDir>
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+  <codecFactory class="solr.SchemaCodecFactory"/>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+  <indexConfig>
+    <lockType>${solr.lock.type:native}</lockType>
+  </indexConfig>
+
+  <!-- The default high-performance update handler -->
+  <updateHandler class="solr.DirectUpdateHandler2">
+    <updateLog>
+      <str name="dir">${solr.ulog.dir:}</str>
+    </updateLog>
+    <autoCommit>
+      <maxTime>15000</maxTime>
+      <openSearcher>false</openSearcher>
+    </autoCommit>
+  </updateHandler>
+
+  <jmx />
+
+  <!-- Required for Solr Cloud on sul-solr -->
+  <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />
+  <requestHandler name="/get" class="solr.RealTimeGetHandler">
+   <lst name="defaults">
+     <str name="omitHeader">true</str>
+   </lst>
+  </requestHandler>
+
+  <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       Query section - these settings control query time things like caches
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
+  <query>
+    <maxBooleanClauses>1024</maxBooleanClauses>
+    <filterCache class="solr.FastLRUCache" size="512" initialSize="512" autowarmCount="0"/>
+    <queryResultCache class="solr.LRUCache" size="512" initialSize="512" autowarmCount="0"/>
+    <documentCache class="solr.LRUCache" size="512" initialSize="512" autowarmCount="0"/>
+    <enableLazyFieldLoading>true</enableLazyFieldLoading>
+    <queryResultWindowSize>20</queryResultWindowSize>
+    <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
+    <listener event="newSearcher" class="solr.QuerySenderListener">
+      <arr name="queries">
+       <lst><str name="q">stanford</str></lst>
+       <lst><str name="q">polygon</str></lst>
+      </arr>
+    </listener>
+    <listener event="firstSearcher" class="solr.QuerySenderListener">
+      <arr name="queries">
+        <lst>
+          <str name="q">static firstSearcher warming in solrconfig.xml</str>
+        </lst>
+      </arr>
+    </listener>
+    <useColdSearcher>false</useColdSearcher>
+    <maxWarmingSearchers>2</maxWarmingSearchers>
+  </query>
+
+  <requestDispatcher handleSelect="false">
+    <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048000" formdataUploadLimitInKB="2048" addHttpRequestToContext="false"/>
+    <httpCaching never304="true"/>
+   </requestDispatcher>
+
+  <requestHandler name="/search" class="solr.SearchHandler"/>
+
+  <requestHandler name="/select" class="solr.SearchHandler">
+    <lst name="defaults">
+      <int name="start">0</int>
+      <int name="rows">10</int>
+      <str name="wt">json</str>
+      <int name="indent">2</int>
+      <str name="defType">edismax</str>
+      <str name="echoParams">all</str>
+      <str name="mm">6&lt;-1 6&lt;90%</str>
+      <int name="qs">1</int>
+      <int name="ps">0</int>
+      <float name="tie">0.01</float>
+      <str name="fl">*,score</str>
+      <str name="sort">score desc, dc_title_sort asc</str>
+      <str name="q.alt">*:*</str>
+      <str name="qf">
+        text^1
+        dc_description_ti^2
+        dc_creator_tmi^3
+        dc_publisher_ti^3
+        dct_isPartOf_tmi^4
+        dc_subject_tmi^5
+        dct_spatial_tmi^5
+        dct_temporal_tmi^5
+        dc_title_ti^6
+        dc_rights_ti^7
+        dct_provenance_ti^8
+        layer_geom_type_ti^9
+        layer_slug_ti^10
+        dc_identifier_ti^10
+      </str>
+      <str name="pf"><!-- phrase boost within result set -->
+        text^1
+        dc_description_ti^2
+        dc_creator_tmi^3
+        dc_publisher_ti^3
+        dct_isPartOf_tmi^4
+        dc_subject_tmi^5
+        dct_spatial_tmi^5
+        dct_temporal_tmi^5
+        dc_title_ti^6
+        dc_rights_ti^7
+        dct_provenance_ti^8
+        layer_geom_type_ti^9
+        layer_slug_ti^10
+        dc_identifier_ti^10
+      </str>
+      <bool name="facet">true</bool>
+      <int name="facet.mincount">1</int>
+      <int name="facet.limit">10</int>
+      <str name="facet.field">dct_isPartOf_sm</str>
+      <str name="facet.field">dct_provenance_s</str>
+      <str name="facet.field">dct_spatial_sm</str>
+      <str name="facet.field">dc_creator_sm</str>
+      <str name="facet.field">dc_format_s</str>
+      <str name="facet.field">dc_language_s</str>
+      <str name="facet.field">dc_publisher_s</str>
+      <str name="facet.field">dc_rights_s</str>
+      <str name="facet.field">dc_subject_sm</str>
+      <str name="facet.field">layer_geom_type_s</str>
+      <str name="facet.field">solr_year_i</str>
+
+      <str name="spellcheck">true</str>
+    </lst>
+
+    <arr name="last-components">
+      <str>spellcheck</str>
+    </arr>
+  </requestHandler>
+
+  <!-- ping/healthcheck -->
+  <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
+    <lst name="invariants">
+      <str name="q">solrpingquery</str>
+    </lst>
+    <lst name="defaults">
+      <str name="echoParams">all</str>
+    </lst>
+    <!-- An optional feature of the PingRequestHandler is to configure the
+         handler with a "healthcheckFile" which can be used to enable/disable
+         the PingRequestHandler.
+         relative paths are resolved against the data dir
+      -->
+    <str name="healthcheckFile">server-enabled.txt</str>
+  </requestHandler>
+
+  <requestHandler name="/analysis/field"
+                  startup="lazy"
+                  class="solr.FieldAnalysisRequestHandler" />
+
+  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+    <!-- a spellchecker built from a field of the main index -->
+    <lst name="spellchecker">
+      <str name="name">default</str>
+      <str name="field">spell</str>
+      <str name="classname">solr.DirectSolrSpellChecker</str>
+      <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
+      <str name="distanceMeasure">internal</str>
+      <!-- minimum accuracy needed to be considered a valid spellcheck suggestion -->
+      <float name="accuracy">0.5</float>
+      <!-- the maximum #edits we consider when enumerating terms: can be 1 or 2 -->
+      <int name="maxEdits">2</int>
+      <!-- the minimum shared prefix when enumerating terms -->
+      <int name="minPrefix">1</int>
+      <!-- maximum number of inspections per result. -->
+      <int name="maxInspections">5</int>
+      <!-- minimum length of a query term to be considered for correction -->
+      <int name="minQueryLength">4</int>
+      <!-- maximum threshold of documents a query term can appear to be considered for correction -->
+      <float name="maxQueryFrequency">0.01</float>
+      <!-- uncomment this to require suggestions to occur in 1% of the documents
+      	<float name="thresholdTokenFrequency">.01</float>
+      -->
+    </lst>
+  </searchComponent>
+
+  <searchComponent name="suggest" class="solr.SuggestComponent">
+    <lst name="suggester">
+      <str name="name">mySuggester</str>
+      <str name="lookupImpl">FuzzyLookupFactory</str>
+      <str name="suggestAnalyzerFieldType">textSuggest</str>
+      <str name="buildOnCommit">true</str>
+      <str name="field">suggest</str>
+    </lst>
+  </searchComponent>
+
+  <requestHandler name="/suggest" class="solr.SearchHandler" startup="lazy">
+    <lst name="defaults">
+      <str name="suggest">true</str>
+      <str name="suggest.count">5</str>
+      <str name="suggest.dictionary">mySuggester</str>
+    </lst>
+    <arr name="components">
+      <str>suggest</str>
+    </arr>
+  </requestHandler>
+</config>


### PR DESCRIPTION
We are upgrading EarthWorks to GeoBlacklight v1.0 (from v0.x). This includes some changes in the Solr configuration.

This PR adds a new core called `kurma-earthworks-v1-dev`.  Later we will create `-stage` and `-prod` cores once we've tested this development version out.

Note that our index version is set to `6.1.0`. The specs are failing -- see https://github.com/sul-dlss/sul-solr-configs/blob/master/spec/cores/solrconfig_spec.rb#L34. It's also failing on the missing `jmx` but I don't see that on the Consul docs, so not sure what to put there...

@sul-devops-team @sul-dlss/devops @mejackreed 