### PR TITLE
Introduce some geo types and new dynamic fields

### DIFF
--- a/exhibits_stage/schema.xml
+++ b/exhibits_stage/schema.xml
@@ -256,7 +256,9 @@
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_ng" type="text_en_ng" stored="false" indexed="true" multiValued="true"/>
     <dynamicField name="*_pt" type="location" stored="true" indexed="true"/>
-    <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_bbox" type="bbox" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_srpt" type="location_rpt" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_geohash" type="geohash" stored="true" indexed="true" multiValued="true"/>
   </fields>
 
   <!-- copy fields -->
@@ -522,17 +524,21 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+    <!-- A Geohash is a compact representation of a latitude longitude pair in a single field.
+      See http://wiki.apache.org/solr/SpatialSearch
+    -->
+    <fieldtype name="geohash" class="solr.GeoHashField"/>
 
-    <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
+    <!-- A specialized field for geospatial search. If indexed, fields of this type must NOT be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
 
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
-    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
-      geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
-
+    <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType" geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers"/>
+    <fieldType name="bbox"         class="solr.BBoxField" geo="true" distanceUnits="kilometers" numberType="_bbox_coord" storeSubFields="false"/>
+    <fieldType name="_bbox_coord"  class="solr.TrieDoubleField" precisionStep="8" docValues="true" stored="false"/>
   </types>
 
 </schema>


### PR DESCRIPTION
Needed for Spatial Recursive Prefix Tree features (heatmaps).

Introduces new dynamic namespaces:
- `*_bbox` as `solr.BBoxType` (previously SRPT)
- `*_srpt` for `solr.SpatialRecursivePrefixTreeFieldType`
- `*_geohash` for `solr.GeoHashField`