### PR TITLE
Add fields and configs for multi-lingual fulltext indexing in exhibits...

### DIFF
--- a/exhibits_stage/schema.xml
+++ b/exhibits_stage/schema.xml
@@ -248,6 +248,9 @@
 
     <!-- exhibits fields -->
     <field name="full_text_search" type="text" indexed="true" stored="true" termVectors="true" termPositions="true" termOffsets="true" multiValued="true" />
+    <field name="full_text_search_en" type="text_en" indexed="true" stored="true" termVectors="true" termPositions="true" termOffsets="true" multiValued="true" />
+    <field name="full_text_search_pt" type="text_pt" indexed="true" stored="true" termVectors="true" termPositions="true" termOffsets="true" multiValued="true" />
+    <field name="full_text_search_id" type="text_id" indexed="true" stored="true" termVectors="true" termPositions="true" termOffsets="true" multiValued="true" />
     <field name="full_text_unstem_search" type="textNoStem" indexed="true" stored="true" multiValued="true" />
     <!-- NOTE:  *_tesim fields are copied into all_search which is meant for metadata, not full text.  Use _tesimv for full text -->
     <dynamicField name="*_tesim" type="text" stored="true" indexed="true" multiValued="true" omitNorms="true" />
@@ -341,6 +344,9 @@
   <!-- NOTE:  full_text_search is meant for full text -->
   <copyField source="*_tesimv" dest="full_text_search" />
   <copyField source="full_text_search" dest="full_text_unstem_search" />
+  <copyField source="*_tesimv" dest="full_text_search_en"/>
+  <copyField source="*_tesimv" dest="full_text_search_pt"/>
+  <copyField source="*_tesimv" dest="full_text_search_id"/>
 
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
@@ -361,16 +367,85 @@
 
     <!-- Analyzed Text, general case -->
     <fieldtype name="text" class="solr.TextField" positionIncrementGap="10000" autoGeneratePhraseQueries="true">
-      <analyzer>
+      <analyzer type="index">
         <tokenizer class="solr.WhitespaceTokenizerFactory" />
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
-        <filter class="solr.WordDelimiterFilterFactory"
-          splitOnCaseChange="1" generateWordParts="1" catenateWords="1"
-          splitOnNumerics="0" generateNumberParts="1" catenateNumbers="1"
-          catenateAll="0" preserveOriginal="0" stemEnglishPossessive="1" />
+        <filter class="solr.SnowballPorterFilterFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+        <filter class="solr.HyphenatedWordsFilterFactory"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldtype>
+
+    <!-- Analyzed Text, English -->
+    <fieldtype name="text_en" class="solr.TextField" positionIncrementGap="10000" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
         <filter class="solr.SnowballPorterFilterFactory" language="English"/>
-        <filter class="solr.RemoveDuplicatesTokenFilterFactory" />
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+        <filter class="solr.HyphenatedWordsFilterFactory"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.EnglishMinimalStemFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldtype>
+
+    <!-- Analyzed Text, Portuguese -->
+    <fieldtype name="text_pt" class="solr.TextField" positionIncrementGap="10000" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.PortugueseLightStemFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+        <filter class="solr.HyphenatedWordsFilterFactory"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.PortugueseLightStemFilterFactory"/>
+        <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldtype>
+
+    <!-- Analyzed Text, Indonesian -->
+    <fieldtype name="text_id" class="solr.TextField" positionIncrementGap="10000" autoGeneratePhraseQueries="true">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true" />
+        <filter class="solr.TrimFilterFactory"/>
+        <filter class="solr.HyphenatedWordsFilterFactory"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory" />
+        <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true" />
+        <filter class="solr.TrimFilterFactory"/>
       </analyzer>
     </fieldtype>
 
@@ -490,7 +565,6 @@
       </analyzer>
     </fieldType>
 
-
     <!-- exhibits fieldTypes below -->
 
     <!-- A text field with defaults appropriate for English and NGrams -->
@@ -525,6 +599,7 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+
     <!-- A Geohash is a compact representation of a latitude longitude pair in a single field.
       See http://wiki.apache.org/solr/SpatialSearch
     -->

--- a/exhibits_stage/schema.xml
+++ b/exhibits_stage/schema.xml
@@ -145,13 +145,12 @@
     <field name="pub_country" type="text" indexed="true" stored="true" omitNorms="true"/>
     <!-- TODO: should pub_date_search be a date or a text field? -->
     <field name="pub_date_search" type="text" indexed="true" stored="true" omitNorms="true"/>
+    <!-- pub_date_sort now deprecated; replaced by pub_year_isi -->
     <field name="pub_date_sort" type="alphaSort" indexed="true" stored="true" />
     <!-- Pub Date Facet Fields -->
-    <!-- pub_date was facet and display, now deprecated -->
-    <field name="pub_date" type="string" indexed="true" stored="true" />
+    <!-- pub_year_tisim is for date slider;  pub_year_w_approx_isi/pub_year_no_approx_isi are other facets -->
     <field name="pub_year_tisim" type="tint" indexed="true" stored="true" multiValued="true" />
     <field name="pub_display" type="string" indexed="false" stored="true" multiValued="true"/>
-    <field name="pub_date_display" type="string" indexed="false" stored="true"/>
     <field name="imprint_display" type="string" indexed="false" stored="true" multiValued="true"/>
 
     <!-- URL Fields -->
@@ -265,7 +264,7 @@
 
   <!-- copy fields -->
   <copyField source="collection" dest="collection_search" />
-  <copyField source="pub_date" dest="pub_date_search" />
+  <copyField source="pub_year_w_approx_isi" dest="pub_date_search" />
   <copyField source="db_az_subject" dest="db_az_subject_search" />
 
   <!-- unstemmed and anchored search fields: title -->

--- a/exhibits_stage/solrconfig.xml
+++ b/exhibits_stage/solrconfig.xml
@@ -726,6 +726,22 @@
         full_text_search^2
       </str>
 
+      <str name="qf_toc_search">
+        toc_unstem_search^5
+        toc_search
+      </str>
+      <str name="pf_toc_search">
+        toc_unstem_search^25
+        toc_search^5
+      </str>
+      <str name="pf3_toc_search">
+        toc_unstem_search^15
+        toc_search^3
+      </str>
+      <str name="pf2_toc_search">
+        toc_unstem_search^10
+        toc_search^2
+      </str>
 
       <bool name="facet">true</bool>
       <int name="facet.mincount">1</int>

--- a/exhibits_stage/solrconfig.xml
+++ b/exhibits_stage/solrconfig.xml
@@ -33,7 +33,7 @@
     <lst name="defaults">
       <str name="defType">edismax</str>
       <str name="echoParams">explicit</str>
-      <str name="sort">score desc, pub_date_sort desc, title_sort asc</str>
+      <str name="sort">score desc, pub_year_isi desc, title_sort asc</str>
       <int name="rows">20</int>
       <str name="q.alt">*:*</str>
       <str name="mm">6&lt;-1 6&lt;90%</str>
@@ -774,7 +774,8 @@
         <str name="f.format.facet.method">enum</str>
       <str name="facet.field">geographic_facet</str>
       <str name="facet.field">language</str>
-      <str name="facet.field">pub_date</str>
+      <str name="facet.field">pub_year_no_approx_isi</str>
+      <str name="facet.field">pub_year_w_approx_isi</str>
       <str name="facet.field">pub_year_tisim</str>
       <str name="facet.field">topic_facet</str>
       <str name="facet.field">collection_with_title</str>
@@ -809,7 +810,6 @@
         modsxml,
         oclc,
         physical,                     vern_physical,
-        pub_date,
         publication_year_isi,
         beginning_year_isi,
         earliest_year_isi,
@@ -822,7 +822,6 @@
         production_year_isi,
         original_year_isi,
         copyright_year_isi,
-        pub_date_display,
         summary_display,
         title_245a_display,           vern_title_245a_display,
         title_245c_display,           vern_title_245c_display,

--- a/exhibits_stage/solrconfig.xml
+++ b/exhibits_stage/solrconfig.xml
@@ -105,6 +105,9 @@
         all_search                     vern_all_search
         full_text_unstem_search^2.5
         full_text_search^0.5
+        full_text_search_en^0.5
+        full_text_search_pt^0.5
+        full_text_search_id^0.5
       </str>
       <str name="pf"> <!-- (phrase boost within result set) -->
         title_245a_exact_search^5000
@@ -161,6 +164,9 @@
         all_search^5                   vern_all_search^5
         full_text_unstem_search^12.5
         full_text_search^2.5
+        full_text_search_en^2.5
+        full_text_search_pt^2.5
+        full_text_search_id^2.5
       </str>
       <str name="pf3">  <!-- (token trigrams boost within result set) -->
         title_245a_search^1500         vern_title_245a_search^1500
@@ -191,6 +197,9 @@
         collection_search^3
         all_search^3                   vern_all_search^3
         full_text_search^1.5
+        full_text_search_en^1.5
+        full_text_search_pt^1.5
+        full_text_search_id^1.5
       </str>
       <str name="pf2"> <!--(token bigrams boost within result set) -->
         title_245a_search^1000         vern_title_245a_search^1000
@@ -221,6 +230,9 @@
         collection_search^2
         all_search^2                   vern_all_search^2
         full_text_search
+        full_text_search_en
+        full_text_search_pt
+        full_text_search_id
       </str>
 
       <str name="qf_cjk">
@@ -712,18 +724,30 @@
       <str name="qf_full_text">
         full_text_unstem_search^5
         full_text_search
+        full_text_search_en
+        full_text_search_pt
+        full_text_search_id
       </str>
       <str name="pf_full_text">
         full_text_unstem_search^25
         full_text_search^5
+        full_text_search_en^5
+        full_text_search_pt^5
+        full_text_search_id^5
       </str>
       <str name="pf3_full_text">
         full_text_unstem_search^15
         full_text_search^3
+        full_text_search_en^3
+        full_text_search_pt^3
+        full_text_search_id^3
       </str>
       <str name="pf2_full_text">
         full_text_unstem_search^10
         full_text_search^2
+        full_text_search_en^2
+        full_text_search_pt^2
+        full_text_search_id^2
       </str>
 
       <str name="qf_toc_search">
@@ -784,7 +808,7 @@
       <str name="facet.field">collection_with_title</str>
 
       <!-- Highlighting defaults -->
-      <str name="hl.fl">all_search full_text_search</str>
+      <str name="hl.fl">all_search full_text_search full_text_search_en full_text_search_pt full_text_search_id</str>
 
       <str name="fl">
         score,

--- a/exhibits_stage/solrconfig.xml
+++ b/exhibits_stage/solrconfig.xml
@@ -667,19 +667,6 @@
       </str>
 
 
-      <!-- for course reserves searches -->
-      <str name="qf_crez">
-        crez_instructor_search
-        crez_course_name_search
-        crez_course_id_search
-      </str>
-      <str name="pf_crez">
-        crez_instructor_search^2
-        crez_course_name_search^2
-      </str>
-      <str name="sort_crez">score desc, title_sort asc, pub_date_sort desc</str>
-
-
       <!-- for advanced search publisher text box -->
       <str name="qf_pub_info">
         pub_search                     vern_pub_search


### PR DESCRIPTION
...stage.

There are various commits that are just trying to get our configs in-line w/ what we're developing with locally.  We've removed some deprecated fields from our local configs but not in the production configs.  I've validated that the only document that still has a `pub_date` in it is not associated w/ an exhibit (and the exhibit it was associated with was a test exhibit that has since been deleted).