### PR TITLE
Update access collections to use stored fields for all incoming data

### DIFF
--- a/arclight-demo/schema.xml
+++ b/arclight-demo/schema.xml
@@ -497,7 +497,7 @@
    <dynamicField name="random_*" type="random" />
 
    <dynamicField name="*_display" type="string" indexed="false" stored="true" multiValued="true" />
-   <dynamicField name="*_facet" type="string" indexed="true" stored="false" multiValued="true" />
+   <dynamicField name="*_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <dynamicField name="*_sort" type="alphaNumericSort" indexed="true" stored="false" multiValued="false" />
    <dynamicField name="*_unstem_search" type="text_general" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
@@ -509,18 +509,18 @@
         unknown fields indexed and/or stored by default -->
    <!--dynamicField name="*" type="ignored" multiValued="true" /-->
 
-   <dynamicField name="*_tesim" type="text_en"   stored="true"  indexed="true"  multiValued="true"  />
-   <dynamicField name="*_teim"  type="text_en"   stored="false" indexed="true"  multiValued="true"  />
-   <dynamicField name="*_si"    type="string"    stored="false" indexed="true"  multiValued="false" />
-   <dynamicField name="*_sim"   type="string"    stored="false" indexed="true"  multiValued="true"  />
-   <dynamicField name="*_ssm"   type="string"    stored="true"  indexed="false" multiValued="true"  />
-   <dynamicField name="*_ssi"   type="string"    stored="true"  indexed="true"  multiValued="false" />
-   <dynamicField name="*_ssim"  type="string"    stored="true"  indexed="true"  multiValued="true"  />
-   <dynamicField name="*_dtsi"  type="date"      stored="true"  indexed="true"  multiValued="false" />
-   <dynamicField name="*_dtsim" type="date"      stored="true"  indexed="true"  multiValued="true"  />
-   <dynamicField name="*_bsi"   type="boolean"   stored="true"  indexed="true"  multiValued="false" />
-   <dynamicField name="*_isim"  type="int"       stored="true"  indexed="true"  multiValued="true"  />
-   <dynamicField name="*_ii"    type="int"       stored="false" indexed="true"  multiValued="false" />
+   <dynamicField name="*_tesim" type="text_en"   stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_teim"  type="text_en"   stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_si"    type="string"    stored="true" indexed="true"  multiValued="false" />
+   <dynamicField name="*_sim"   type="string"    stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_ssm"   type="string"    stored="true" indexed="false" multiValued="true"  />
+   <dynamicField name="*_ssi"   type="string"    stored="true" indexed="true"  multiValued="false" />
+   <dynamicField name="*_ssim"  type="string"    stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_dtsi"  type="date"      stored="true" indexed="true"  multiValued="false" />
+   <dynamicField name="*_dtsim" type="date"      stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_bsi"   type="boolean"   stored="true" indexed="true"  multiValued="false" />
+   <dynamicField name="*_isim"  type="int"       stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_ii"    type="int"       stored="true" indexed="true"  multiValued="false" />
 
  </fields>
 

--- a/arclight-prod/schema.xml
+++ b/arclight-prod/schema.xml
@@ -497,7 +497,7 @@
    <dynamicField name="random_*" type="random" />
 
    <dynamicField name="*_display" type="string" indexed="false" stored="true" multiValued="true" />
-   <dynamicField name="*_facet" type="string" indexed="true" stored="false" multiValued="true" />
+   <dynamicField name="*_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <dynamicField name="*_sort" type="alphaNumericSort" indexed="true" stored="false" multiValued="false" />
    <dynamicField name="*_unstem_search" type="text_general" indexed="true" stored="false" multiValued="true" />
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
@@ -509,18 +509,18 @@
         unknown fields indexed and/or stored by default -->
    <!--dynamicField name="*" type="ignored" multiValued="true" /-->
 
-   <dynamicField name="*_tesim" type="text_en"   stored="true"  indexed="true"  multiValued="true"  />
-   <dynamicField name="*_teim"  type="text_en"   stored="false" indexed="true"  multiValued="true"  />
-   <dynamicField name="*_si"    type="string"    stored="false" indexed="true"  multiValued="false" />
-   <dynamicField name="*_sim"   type="string"    stored="false" indexed="true"  multiValued="true"  />
-   <dynamicField name="*_ssm"   type="string"    stored="true"  indexed="false" multiValued="true"  />
-   <dynamicField name="*_ssi"   type="string"    stored="true"  indexed="true"  multiValued="false" />
-   <dynamicField name="*_ssim"  type="string"    stored="true"  indexed="true"  multiValued="true"  />
-   <dynamicField name="*_dtsi"  type="date"      stored="true"  indexed="true"  multiValued="false" />
-   <dynamicField name="*_dtsim" type="date"      stored="true"  indexed="true"  multiValued="true"  />
-   <dynamicField name="*_bsi"   type="boolean"   stored="true"  indexed="true"  multiValued="false" />
-   <dynamicField name="*_isim"  type="int"       stored="true"  indexed="true"  multiValued="true"  />
-   <dynamicField name="*_ii"    type="int"       stored="false" indexed="true"  multiValued="false" />
+   <dynamicField name="*_tesim" type="text_en"   stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_teim"  type="text_en"   stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_si"    type="string"    stored="true" indexed="true"  multiValued="false" />
+   <dynamicField name="*_sim"   type="string"    stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_ssm"   type="string"    stored="true" indexed="false" multiValued="true"  />
+   <dynamicField name="*_ssi"   type="string"    stored="true" indexed="true"  multiValued="false" />
+   <dynamicField name="*_ssim"  type="string"    stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_dtsi"  type="date"      stored="true" indexed="true"  multiValued="false" />
+   <dynamicField name="*_dtsim" type="date"      stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_bsi"   type="boolean"   stored="true" indexed="true"  multiValued="false" />
+   <dynamicField name="*_isim"  type="int"       stored="true" indexed="true"  multiValued="true"  />
+   <dynamicField name="*_ii"    type="int"       stored="true" indexed="true"  multiValued="false" />
 
  </fields>
 

--- a/bassi/schema.xml
+++ b/bassi/schema.xml
@@ -8,67 +8,67 @@
     <field name="_version_" type="long"     indexed="true"  stored="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
-    <field name="text" type="text" stored="false" indexed="true" multiValued="true"/>
+    <field name="text" type="text" stored="true"  indexed="true" multiValued="true"/>
 
     <field name="lat" type="tdouble" stored="true" indexed="true" multiValued="false"/>
     <field name="lng" type="tdouble" stored="true" indexed="true" multiValued="false"/>
 
-    <dynamicField name="*_ti" type="text" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_tim" type="text" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_ti" type="text" stored="true"  indexed="true" multiValued="false"/>
+    <dynamicField name="*_tim" type="text" stored="true"  indexed="true" multiValued="true"/>
     <dynamicField name="*_ts" type="text" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_tsm" type="text" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_tsi" type="text" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_tsim" type="text" stored="true" indexed="true" multiValued="true"/>
-    <dynamicField name="*_tiv" type="text" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
-    <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_tiv" type="text" stored="true"  indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
+    <dynamicField name="*_timv" type="text" stored="true"  indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsiv" type="text" stored="true" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_tsimv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-    
-    <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true"/>
+
+    <dynamicField name="*_si" type="string" stored="true"  indexed="true" multiValued="false"/>
+    <dynamicField name="*_sim" type="string" stored="true"  indexed="true" multiValued="true"/>
     <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true"/>
-    
-    <dynamicField name="*_ii" type="int" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_iim" type="int" stored="false" indexed="true" multiValued="true"/>
+
+    <dynamicField name="*_ii" type="int" stored="true"  indexed="true" multiValued="false"/>
+    <dynamicField name="*_iim" type="int" stored="true"  indexed="true" multiValued="true"/>
     <dynamicField name="*_is" type="int" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_ism" type="int" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_isi" type="int" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_isim" type="int" stored="true" indexed="true" multiValued="true"/>
-    
-    <dynamicField name="*_iti" type="tint" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_itim" type="tint" stored="false" indexed="true" multiValued="true"/>
+
+    <dynamicField name="*_iti" type="tint" stored="true"  indexed="true" multiValued="false"/>
+    <dynamicField name="*_itim" type="tint" stored="true"  indexed="true" multiValued="true"/>
     <dynamicField name="*_its" type="tint" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_itsm" type="tint" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_itsi" type="tint" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_itsim" type="tint" stored="true" indexed="true" multiValued="true"/>
-    
-    <dynamicField name="*_di" type="date" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dim" type="date" stored="false" indexed="true" multiValued="true"/>
+
+    <dynamicField name="*_di" type="date" stored="true"  indexed="true" multiValued="false"/>
+    <dynamicField name="*_dim" type="date" stored="true"  indexed="true" multiValued="true"/>
     <dynamicField name="*_ds" type="date" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_dsm" type="date" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dsi" type="date" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dsim" type="date" stored="true" indexed="true" multiValued="true"/>
-    
-    <dynamicField name="*_dti" type="tdate" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_dtim" type="tdate" stored="false" indexed="true" multiValued="true"/>
+
+    <dynamicField name="*_dti" type="tdate" stored="true"  indexed="true" multiValued="false"/>
+    <dynamicField name="*_dtim" type="tdate" stored="true"  indexed="true" multiValued="true"/>
     <dynamicField name="*_dts" type="tdate" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_dtsm" type="tdate" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_dtsi" type="tdate" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_dtsim" type="tdate" stored="true" indexed="true" multiValued="true"/>
-    
-    <dynamicField name="*_bi" type="boolean" stored="false" indexed="true" multiValued="false"/>
+
+    <dynamicField name="*_bi" type="boolean" stored="true"  indexed="true" multiValued="false"/>
     <dynamicField name="*_bs" type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="false"/>
-    
+
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
-    <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="false" />
+    <dynamicField name="*_coordinate" type="tdouble" indexed="true"  stored="true"  />
     <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
 
-    <dynamicField name="*_lli" type="location" stored="false" indexed="true" multiValued="false"/>
-    <dynamicField name="*_llim" type="location" stored="false" indexed="true" multiValued="true"/>
+    <dynamicField name="*_lli" type="location" stored="true"  indexed="true" multiValued="false"/>
+    <dynamicField name="*_llim" type="location" stored="true"  indexed="true" multiValued="true"/>
     <dynamicField name="*_lls" type="location" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_llsm" type="location" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_llsi" type="location" stored="true" indexed="true" multiValued="false"/>
@@ -78,32 +78,32 @@
 
   <types>
     <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
-    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>    
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
-    
+
     <!-- Default numeric field types.  -->
     <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
     <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
-    
+
     <!-- trie numeric field types for faster range queries -->
     <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
     <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
-    
+
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
     <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
     <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
-    
-    
+
+
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -113,31 +113,31 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    
+
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
     <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-    
+
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
       http://wiki.apache.org/solr/SolrAdaptersForLuceneSpatial4
     -->
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
       geo="true" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees" />
-    
+
     <fieldType name="text" class="solr.TextField" omitNorms="false">
       <analyzer>
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
       </analyzer>
     </fieldType>
-    
+
     <!-- A text field that only splits on whitespace for exact matching of words -->
     <fieldType name="text_ws" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
       </analyzer>
     </fieldType>
-        
+
     <!-- single token analyzed text, for sorting.  Punctuation is significant. -->
     <fieldtype name="alphaSort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
@@ -146,7 +146,7 @@
         <filter class="solr.TrimFilterFactory" />
       </analyzer>
     </fieldtype>
-    
+
     <!-- A text field with defaults appropriate for English -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -160,8 +160,8 @@
         -->
       </analyzer>
     </fieldType>
-        
-    
+
+
     <!-- queries for paths match documents at that path, or in descendent paths -->
     <fieldType name="descendent_path" class="solr.TextField">
       <analyzer type="index">
@@ -171,7 +171,7 @@
         <tokenizer class="solr.KeywordTokenizerFactory" />
       </analyzer>
     </fieldType>
-    
+
     <!-- queries for paths match documents at that path, or in ancestor paths -->
     <fieldType name="ancestor_path" class="solr.TextField">
       <analyzer type="index">
@@ -181,8 +181,7 @@
         <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/" />
       </analyzer>
     </fieldType>
-    
-  </types>
-  
-</schema>
 
+  </types>
+
+</schema>

--- a/dms-discovery-prod/schema.xml
+++ b/dms-discovery-prod/schema.xml
@@ -13,42 +13,42 @@
     <!-- the catch-all field for all text -->
     <field name="all_search" type="text" indexed="true" stored="false" multiValued="true" />
     <field name="all_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- Abstract -->
-    <field name="abstract_search" type="text" indexed="true" stored="false" />
+    <field name="abstract_search" type="text" indexed="true" stored="true" />
     <field name="abstract_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="abstract_display" type="string" indexed="false" stored="true" />
-    
+
     <!-- Access condition -->
-    <field name="access_condition_search" type="text" indexed="true" stored="false" />
+    <field name="access_condition_search" type="text" indexed="true" stored="true" />
     <field name="access_condition_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="access_condition_display" type="string" indexed="false" stored="true" />
-    
+
     <!-- Genre -->
-    <field name="genre_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="genre_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="genre_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="genre_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="genre_facet" type="string" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- Type of resource -->
-    <field name="type_of_resource_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="type_of_resource_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="type_of_resource_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="type_of_resource_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="type_of_resource_facet" type="string" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- Author: corporate, personal  -->
     <!-- Author: corporate  -->
-    <field name="corporate_authors_search" type="text" indexed="true" stored="false"  multiValued="true" />
+    <field name="corporate_authors_search" type="text" indexed="true" stored="true"  multiValued="true" />
     <field name="corporate_authors_unstem_search" type="textNoStem" indexed="true" stored="false"  multiValued="true" />
     <field name="corporate_authors_display" type="string" indexed="false" stored="true"  multiValued="true" />
     <field name="corporate_authors_facet" type="string" indexed="true" stored="false"  multiValued="true" />
     <!-- Author: personal  -->
-    <field name="personal_authors_search" type="text" indexed="true" stored="false"  multiValued="true" />
+    <field name="personal_authors_search" type="text" indexed="true" stored="true"  multiValued="true" />
     <field name="personal_authors_unstem_search" type="textNoStem" indexed="true" stored="false"  multiValued="true" />
     <field name="personal_authors_display" type="string" indexed="false" stored="true"  multiValued="true" />
     <field name="personal_authors_facet" type="string" indexed="true" stored="false"  multiValued="true" />
     <!-- Author: all  -->
-    <field name="authors_all_search" type="text" indexed="true" stored="false"  multiValued="true" />
+    <field name="authors_all_search" type="text" indexed="true" stored="true"  multiValued="true" />
     <field name="authors_all_unstem_search" type="textNoStem" indexed="true" stored="false"  multiValued="true" />
     <field name="authors_all_display" type="string" indexed="false" stored="true"  multiValued="true" />
     <field name="authors_all_facet" type="string" indexed="true" stored="false"  multiValued="true" />
@@ -56,45 +56,45 @@
     <!-- Title fields: title, title variant, subtitle -->
     <!-- Title fields: title -->
     <field name="title_exact_search" type="text_anchored" indexed="true" stored="false" />
-    <field name="title_search" type="text" indexed="true" stored="false" />
+    <field name="title_search" type="text" indexed="true" stored="true" />
     <field name="title_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="title_display" type="string" indexed="false" stored="true" />
     <field name="title_sort" type="alphaSort" indexed="true" stored="false" />
     <!-- Title fields: title variant -->
-    <field name="title_alternate_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="title_alternate_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="title_alternate_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="title_alternate_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- Title fields: title other -->
-    <field name="title_other_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="title_other_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="title_other_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="title_other_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- Title fields: subtitle -->
-    <field name="subtitle_search" type="text" indexed="true" stored="false" />
+    <field name="subtitle_search" type="text" indexed="true" stored="true" />
     <field name="subtitle_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="subtitle_display" type="string" indexed="false" stored="true" />
 
     <!-- Language -->
     <field name="language" type="string" indexed="true" stored="true" multiValued="true" />
-    
+
     <!-- Physical description fields: extent, form, media_type -->
     <!-- Physical description fields: extent -->
     <field name="physical_description_extent_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- Physical description fields: form -->
-    <field name="physical_description_form_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="physical_description_form_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="physical_description_form_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="physical_description_form_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <!-- Physical description fields: media_type -->
-    <field name="physical_description_media_type_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="physical_description_media_type_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="physical_description_media_type_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="physical_description_media_type_facet" type="string" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- locations fields: physical location, location url -->
     <field name="physical_location_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="location_url_display" type="string" indexed="false" stored="true" multiValued="true" />
 
     <!-- related item fields: title, location url -->
     <field name="relateditem_location_url_display" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="relateditem_title_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="relateditem_title_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="relateditem_title_display" type="string" indexed="false" stored="true" multiValued="true" />
 
     <!-- origin info fields: date_issued, place_terms, publishers -->
@@ -107,39 +107,39 @@
     <field name="pub_date_sort" type="int" indexed="true" stored="false" />
     <field name="pub_date_display" type="string" indexed="false" stored="true"/>
     <!-- origin info fields: place -->
-    <field name="place_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="place_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="place_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <field name="place_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- origin info fields: publishers -->
-    <field name="publishers_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="publishers_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="publishers_display" type="string" indexed="false" stored="true" multiValued="true" />
 
     <!--  Subject Search Fields: topic, geographic, other -->
     <!--  Subject Search Fields: topic -->
-    <field name="topic_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="topic_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="topic_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="topic_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="topic_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <!--  Subject Search Fields: geographic -->
-    <field name="geographic_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="geographic_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="geographic_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="geographic_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="geographic_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <!--  Subject Search Fields: era -->
-    <field name="era_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="era_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="era_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="era_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="era_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <!--  Subject Search Fields: other -->
-    <field name="subject_other_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="subject_other_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="subject_other_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="subject_other_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!--  Subject Search Fields: all -->
-    <field name="subject_all_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="subject_all_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="subject_all_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="subject_all_display" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="subject_all_facet" type="string" indexed="true" stored="false" multiValued="true" />    
-   
+    <field name="subject_all_facet" type="string" indexed="true" stored="false" multiValued="true" />
+
     <!-- Format Field: facet and display -->
     <field name="format" type="string" indexed="true" stored="true" multiValued="true" />
 
@@ -170,13 +170,13 @@
     <field name="collection_with_title" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="img_info" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="file_id" type="string" indexed="false" stored="true" multiValued="true"/>
-    
+
     <!-- *************** additional fields for annotation objects  ****************** -->
     <!-- annotated_at - time of annotation -->
     <field name="annotated_at" type="string" stored="true" indexed="true" />
-    <field name="annotated_at_tdate" type="tdate" stored="false" indexed="true" />
+    <field name="annotated_at_tdate" type="tdate" stored="true" indexed="true" />
     <!-- annotated_by - author of annotation (use author_all) -->
-    <!-- 
+    <!--
     <field name="annotated_by_search" type="text" indexed="true" stored="false"  multiValued="true" />
     <field name="annotated_by_unstem_search" type="textNoStem" indexed="true" stored="false"  multiValued="true" />
     <field name="annotated_by_display" type="string" indexed="false" stored="true"  multiValued="true" />
@@ -194,20 +194,20 @@
     <field name="body_type" type="string" stored="true" indexed="true" multiValued="true"/>
     <!-- body -->
     <field name="body_chars_exact_search" type="text_anchored" indexed="true" stored="false" />
-    <field name="body_chars_search" type="text" indexed="true" stored="false" />
+    <field name="body_chars_search" type="text" indexed="true" stored="true" />
     <field name="body_chars_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="body_chars_display" type="string" indexed="false" stored="true" />
     <field name="body_chars_sort" type="alphaSort" indexed="true" stored="false" />
     <!-- manuscript -->
-    <field name="manuscript_search" type="text" indexed="true" stored="false" />
+    <field name="manuscript_search" type="text" indexed="true" stored="true" />
     <field name="manuscript_display" type="string" indexed="false" stored="true" />
     <field name="manuscript_facet" type="string" indexed="true" stored="false" />
     <field name="manuscript_sort" type="alphaSort" indexed="true" stored="false" />
     <!-- folio: facet and display -->
     <field name="folio" type="string" stored="true" indexed="true" />
     <field name="folio_sort" type="alphaSort" stored="false" indexed="true" />
-    <field name="sort_index" type="tint" indexed="true" stored="false" />
-    
+    <field name="sort_index" type="tint" indexed="true" stored="true" />
+
     <!-- *************** dynamic field types  ****************** -->
     <!--
     <dynamicField name="*_unstem_search" type="textNoStem" stored="false" indexed="true" multiValued="true" />
@@ -216,18 +216,18 @@
     <dynamicField name="*_display" type="string" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_sort" type="alphaSort" stored="false" indexed="true"/>
     -->
-    <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false" omitNorms="true" />
-    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true" omitNorms="true" />
+    <dynamicField name="*_si" type="string" stored="true" indexed="true" multiValued="false" omitNorms="true" />
+    <dynamicField name="*_sim" type="string" stored="true" indexed="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false" omitNorms="true" />
     <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true" omitNorms="true" />
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false" omitNorms="true" />
     <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_isi" type="tint" stored="true" indexed="true" omitNorms="true" />
     <dynamicField name="*_isim" type="tint" stored="true" indexed="true" multiValued="true" omitNorms="true" />
-    <dynamicField name="*_sort" type="alphaSort" stored="false" indexed="true"/>
+    <dynamicField name="*_sort" type="alphaSort" stored="true" indexed="true"/>
     <dynamicField name="*_xml" type="string" stored="true" indexed="false" omitNorms="true" />
-    <dynamicField name="cjk_*" type="text" stored="false" indexed="true" multiValued="true" />
-    <dynamicField name="*_hsim" type="string_hierarch" stored="false" indexed="true" multiValued="true" />
+    <dynamicField name="cjk_*" type="text" stored="true" indexed="true" multiValued="true" />
+    <dynamicField name="*_hsim" type="string_hierarch" stored="true" indexed="true" multiValued="true" />
   </fields>
 
   <!-- copy fields -->
@@ -310,7 +310,7 @@
   <copyField source="topic_search" dest="topic_facet" />
   <copyField source="geographic_search" dest="geographic_facet" />
   <copyField source="era_search" dest="era_facet" />
-  <copyField source="subject_all_search" dest="subject_all_facet" /> 
+  <copyField source="subject_all_search" dest="subject_all_facet" />
   <copyField source="manuscript_search" dest="manuscript_facet" />
 
   <types>

--- a/dms-discovery-stage/schema.xml
+++ b/dms-discovery-stage/schema.xml
@@ -13,42 +13,42 @@
     <!-- the catch-all field for all text -->
     <field name="all_search" type="text" indexed="true" stored="false" multiValued="true" />
     <field name="all_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- Abstract -->
-    <field name="abstract_search" type="text" indexed="true" stored="false" />
+    <field name="abstract_search" type="text" indexed="true" stored="true" />
     <field name="abstract_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="abstract_display" type="string" indexed="false" stored="true" />
-    
+
     <!-- Access condition -->
-    <field name="access_condition_search" type="text" indexed="true" stored="false" />
+    <field name="access_condition_search" type="text" indexed="true" stored="true" />
     <field name="access_condition_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="access_condition_display" type="string" indexed="false" stored="true" />
-    
+
     <!-- Genre -->
-    <field name="genre_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="genre_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="genre_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="genre_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="genre_facet" type="string" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- Type of resource -->
-    <field name="type_of_resource_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="type_of_resource_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="type_of_resource_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="type_of_resource_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="type_of_resource_facet" type="string" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- Author: corporate, personal  -->
     <!-- Author: corporate  -->
-    <field name="corporate_authors_search" type="text" indexed="true" stored="false"  multiValued="true" />
+    <field name="corporate_authors_search" type="text" indexed="true" stored="true"  multiValued="true" />
     <field name="corporate_authors_unstem_search" type="textNoStem" indexed="true" stored="false"  multiValued="true" />
     <field name="corporate_authors_display" type="string" indexed="false" stored="true"  multiValued="true" />
     <field name="corporate_authors_facet" type="string" indexed="true" stored="false"  multiValued="true" />
     <!-- Author: personal  -->
-    <field name="personal_authors_search" type="text" indexed="true" stored="false"  multiValued="true" />
+    <field name="personal_authors_search" type="text" indexed="true" stored="true"  multiValued="true" />
     <field name="personal_authors_unstem_search" type="textNoStem" indexed="true" stored="false"  multiValued="true" />
     <field name="personal_authors_display" type="string" indexed="false" stored="true"  multiValued="true" />
     <field name="personal_authors_facet" type="string" indexed="true" stored="false"  multiValued="true" />
     <!-- Author: all  -->
-    <field name="authors_all_search" type="text" indexed="true" stored="false"  multiValued="true" />
+    <field name="authors_all_search" type="text" indexed="true" stored="true"  multiValued="true" />
     <field name="authors_all_unstem_search" type="textNoStem" indexed="true" stored="false"  multiValued="true" />
     <field name="authors_all_display" type="string" indexed="false" stored="true"  multiValued="true" />
     <field name="authors_all_facet" type="string" indexed="true" stored="false"  multiValued="true" />
@@ -56,45 +56,45 @@
     <!-- Title fields: title, title variant, subtitle -->
     <!-- Title fields: title -->
     <field name="title_exact_search" type="text_anchored" indexed="true" stored="false" />
-    <field name="title_search" type="text" indexed="true" stored="false" />
+    <field name="title_search" type="text" indexed="true" stored="true" />
     <field name="title_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="title_display" type="string" indexed="false" stored="true" />
     <field name="title_sort" type="alphaSort" indexed="true" stored="false" />
     <!-- Title fields: title variant -->
-    <field name="title_alternate_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="title_alternate_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="title_alternate_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="title_alternate_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- Title fields: title other -->
-    <field name="title_other_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="title_other_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="title_other_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="title_other_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- Title fields: subtitle -->
-    <field name="subtitle_search" type="text" indexed="true" stored="false" />
+    <field name="subtitle_search" type="text" indexed="true" stored="true" />
     <field name="subtitle_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="subtitle_display" type="string" indexed="false" stored="true" />
 
     <!-- Language -->
     <field name="language" type="string" indexed="true" stored="true" multiValued="true" />
-    
+
     <!-- Physical description fields: extent, form, media_type -->
     <!-- Physical description fields: extent -->
     <field name="physical_description_extent_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- Physical description fields: form -->
-    <field name="physical_description_form_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="physical_description_form_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="physical_description_form_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="physical_description_form_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <!-- Physical description fields: media_type -->
-    <field name="physical_description_media_type_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="physical_description_media_type_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="physical_description_media_type_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="physical_description_media_type_facet" type="string" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- locations fields: physical location, location url -->
     <field name="physical_location_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="location_url_display" type="string" indexed="false" stored="true" multiValued="true" />
 
     <!-- related item fields: title, location url -->
     <field name="relateditem_location_url_display" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="relateditem_title_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="relateditem_title_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="relateditem_title_display" type="string" indexed="false" stored="true" multiValued="true" />
 
     <!-- origin info fields: date_issued, place_terms, publishers -->
@@ -107,39 +107,39 @@
     <field name="pub_date_sort" type="int" indexed="true" stored="false" />
     <field name="pub_date_display" type="string" indexed="false" stored="true"/>
     <!-- origin info fields: place -->
-    <field name="place_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="place_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="place_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <field name="place_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!-- origin info fields: publishers -->
-    <field name="publishers_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="publishers_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="publishers_display" type="string" indexed="false" stored="true" multiValued="true" />
 
     <!--  Subject Search Fields: topic, geographic, other -->
     <!--  Subject Search Fields: topic -->
-    <field name="topic_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="topic_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="topic_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="topic_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="topic_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <!--  Subject Search Fields: geographic -->
-    <field name="geographic_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="geographic_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="geographic_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="geographic_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="geographic_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <!--  Subject Search Fields: era -->
-    <field name="era_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="era_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="era_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="era_display" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="era_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <!--  Subject Search Fields: other -->
-    <field name="subject_other_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="subject_other_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="subject_other_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="subject_other_display" type="string" indexed="false" stored="true" multiValued="true" />
     <!--  Subject Search Fields: all -->
-    <field name="subject_all_search" type="text" indexed="true" stored="false" multiValued="true" />
+    <field name="subject_all_search" type="text" indexed="true" stored="true" multiValued="true" />
     <field name="subject_all_unstem_search" type="textNoStem" indexed="true" stored="false" multiValued="true" />
     <field name="subject_all_display" type="string" indexed="false" stored="true" multiValued="true" />
-    <field name="subject_all_facet" type="string" indexed="true" stored="false" multiValued="true" />    
-   
+    <field name="subject_all_facet" type="string" indexed="true" stored="false" multiValued="true" />
+
     <!-- Format Field: facet and display -->
     <field name="format" type="string" indexed="true" stored="true" multiValued="true" />
 
@@ -170,13 +170,13 @@
     <field name="collection_with_title" type="string" indexed="false" stored="true" multiValued="true" />
     <field name="img_info" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="file_id" type="string" indexed="false" stored="true" multiValued="true"/>
-    
+
     <!-- *************** additional fields for annotation objects  ****************** -->
     <!-- annotated_at - time of annotation -->
     <field name="annotated_at" type="string" stored="true" indexed="true" />
-    <field name="annotated_at_tdate" type="tdate" stored="false" indexed="true" />
+    <field name="annotated_at_tdate" type="tdate" stored="true" indexed="true" />
     <!-- annotated_by - author of annotation (use author_all) -->
-    <!-- 
+    <!--
     <field name="annotated_by_search" type="text" indexed="true" stored="false"  multiValued="true" />
     <field name="annotated_by_unstem_search" type="textNoStem" indexed="true" stored="false"  multiValued="true" />
     <field name="annotated_by_display" type="string" indexed="false" stored="true"  multiValued="true" />
@@ -194,20 +194,20 @@
     <field name="body_type" type="string" stored="true" indexed="true" multiValued="true"/>
     <!-- body -->
     <field name="body_chars_exact_search" type="text_anchored" indexed="true" stored="false" />
-    <field name="body_chars_search" type="text" indexed="true" stored="false" />
+    <field name="body_chars_search" type="text" indexed="true" stored="true" />
     <field name="body_chars_unstem_search" type="textNoStem" indexed="true" stored="false" />
     <field name="body_chars_display" type="string" indexed="false" stored="true" />
     <field name="body_chars_sort" type="alphaSort" indexed="true" stored="false" />
     <!-- manuscript -->
-    <field name="manuscript_search" type="text" indexed="true" stored="false" />
+    <field name="manuscript_search" type="text" indexed="true" stored="true" />
     <field name="manuscript_display" type="string" indexed="false" stored="true" />
     <field name="manuscript_facet" type="string" indexed="true" stored="false" />
     <field name="manuscript_sort" type="alphaSort" indexed="true" stored="false" />
     <!-- folio: facet and display -->
     <field name="folio" type="string" stored="true" indexed="true" />
     <field name="folio_sort" type="alphaSort" stored="false" indexed="true" />
-    <field name="sort_index" type="tint" indexed="true" stored="false" />
-    
+    <field name="sort_index" type="tint" indexed="true" stored="true" />
+
     <!-- *************** dynamic field types  ****************** -->
     <!--
     <dynamicField name="*_unstem_search" type="textNoStem" stored="false" indexed="true" multiValued="true" />
@@ -216,18 +216,18 @@
     <dynamicField name="*_display" type="string" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_sort" type="alphaSort" stored="false" indexed="true"/>
     -->
-    <dynamicField name="*_si" type="string" stored="false" indexed="true" multiValued="false" omitNorms="true" />
-    <dynamicField name="*_sim" type="string" stored="false" indexed="true" multiValued="true" omitNorms="true" />
+    <dynamicField name="*_si" type="string" stored="true" indexed="true" multiValued="false" omitNorms="true" />
+    <dynamicField name="*_sim" type="string" stored="true" indexed="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_ss" type="string" stored="true" indexed="false" multiValued="false" omitNorms="true" />
     <dynamicField name="*_ssm" type="string" stored="true" indexed="false" multiValued="true" omitNorms="true" />
     <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false" omitNorms="true" />
     <dynamicField name="*_ssim" type="string" stored="true" indexed="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_isi" type="tint" stored="true" indexed="true" omitNorms="true" />
     <dynamicField name="*_isim" type="tint" stored="true" indexed="true" multiValued="true" omitNorms="true" />
-    <dynamicField name="*_sort" type="alphaSort" stored="false" indexed="true"/>
+    <dynamicField name="*_sort" type="alphaSort" stored="true" indexed="true"/>
     <dynamicField name="*_xml" type="string" stored="true" indexed="false" omitNorms="true" />
-    <dynamicField name="cjk_*" type="text" stored="false" indexed="true" multiValued="true" />
-    <dynamicField name="*_hsim" type="string_hierarch" stored="false" indexed="true" multiValued="true" />
+    <dynamicField name="cjk_*" type="text" stored="true" indexed="true" multiValued="true" />
+    <dynamicField name="*_hsim" type="string_hierarch" stored="true" indexed="true" multiValued="true" />
   </fields>
 
   <!-- copy fields -->
@@ -310,7 +310,7 @@
   <copyField source="topic_search" dest="topic_facet" />
   <copyField source="geographic_search" dest="geographic_facet" />
   <copyField source="era_search" dest="era_facet" />
-  <copyField source="subject_all_search" dest="subject_all_facet" /> 
+  <copyField source="subject_all_search" dest="subject_all_facet" />
   <copyField source="manuscript_search" dest="manuscript_facet" />
 
   <types>

--- a/mirador-sas-prod/schema.xml
+++ b/mirador-sas-prod/schema.xml
@@ -142,8 +142,8 @@
       <fieldType name="tlong" class="solr.TrieLongField" positionIncrementGap="0" docValues="true" precisionStep="8"/>
     </types>
     <fields>
-      <field name="_root_" type="string" docValues="false" indexed="true" stored="false"/>
-      <field name="_version_" type="long" indexed="true" stored="false"/>
+      <field name="_root_" type="string" docValues="false" indexed="true" stored="true"/>
+      <field name="_version_" type="long" indexed="true" stored="true"/>
       <field name="body" type="string" multiValued="true" indexed="true" stored="true"/>
       <field name="canvas" type="string" multiValued="true" indexed="true" stored="true"/>
       <field name="created" type="date" multiValued="false" indexed="true" stored="true"/>
@@ -159,7 +159,7 @@
       <field name="text" type="stripHTML_en" multiValued="true" indexed="true" stored="true"/>
       <field name="type" type="string" multiValued="true" indexed="true" stored="true"/>
       <field name="within" type="string" multiValued="true" indexed="true" stored="true"/>
-      <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="false" useDocValuesAsStored="false"/>
+      <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="true" useDocValuesAsStored="false"/>
       <dynamicField name="ignored_*" type="ignored" multiValued="true"/>
       <dynamicField name="random_*" type="random"/>
       <dynamicField name="attr_*" type="text_general" multiValued="true" indexed="true" stored="true"/>

--- a/sul-cms-dev/schema.xml
+++ b/sul-cms-dev/schema.xml
@@ -96,7 +96,7 @@
      and require different update frequencies than the documents they are
      associated with.
     -->
-    <fieldType name="file" keyField="id" defVal="1" stored="false" indexed="false" class="solr.ExternalFileField" />
+    <fieldType name="file" keyField="id" defVal="1" stored="true" indexed="false" class="solr.ExternalFileField" />
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
@@ -423,7 +423,7 @@
 
     <!-- A set of fields to contain text extracted from HTML tag contents which we
          can boost at query time. -->
-    <dynamicField name="tags_*" type="text"   indexed="true" stored="false" omitNorms="true"/>
+    <dynamicField name="tags_*" type="text"   indexed="true" stored="true" omitNorms="true"/>
 
     <!-- For 2 and 3 letter prefix dynamic fields, the 1st letter indicates the data type and
          the last letter is 's' for single valued, 'm' for multi-valued -->
@@ -508,12 +508,12 @@
     <!-- End added fields for Solr 3.4+ -->
 
     <!-- Sortable version of the dynamic string field -->
-    <dynamicField name="sort_*" type="sortString" indexed="true" stored="false"/>
+    <dynamicField name="sort_*" type="sortString" indexed="true" stored="true"/>
     <copyField source="ss_*" dest="sort_*"/>
     <!-- A random sort field -->
     <dynamicField name="random_*" type="rand" indexed="true" stored="true"/>
     <!-- This field is used to store access information (e.g. node access grants), as opposed to field data -->
-    <dynamicField name="access_*" type="integer" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="access_*" type="integer" indexed="true" stored="true" multiValued="true"/>
 
     <!-- The following causes solr to ignore any fields that don't already match an existing
          field name or dynamic field, rather than reporting them as an error.
@@ -532,5 +532,4 @@
        Unless this field is marked with required="false", it will be a required field
     -->
   <uniqueKey>id</uniqueKey>
-
 </schema>

--- a/sul-cms-prod/schema.xml
+++ b/sul-cms-prod/schema.xml
@@ -96,7 +96,7 @@
      and require different update frequencies than the documents they are
      associated with.
     -->
-    <fieldType name="file" keyField="id" defVal="1" stored="false" indexed="false" class="solr.ExternalFileField" />
+    <fieldType name="file" keyField="id" defVal="1" stored="true" indexed="false" class="solr.ExternalFileField" />
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
@@ -423,7 +423,7 @@
 
     <!-- A set of fields to contain text extracted from HTML tag contents which we
          can boost at query time. -->
-    <dynamicField name="tags_*" type="text"   indexed="true" stored="false" omitNorms="true"/>
+    <dynamicField name="tags_*" type="text"   indexed="true" stored="true" omitNorms="true"/>
 
     <!-- For 2 and 3 letter prefix dynamic fields, the 1st letter indicates the data type and
          the last letter is 's' for single valued, 'm' for multi-valued -->
@@ -508,12 +508,12 @@
     <!-- End added fields for Solr 3.4+ -->
 
     <!-- Sortable version of the dynamic string field -->
-    <dynamicField name="sort_*" type="sortString" indexed="true" stored="false"/>
+    <dynamicField name="sort_*" type="sortString" indexed="true" stored="true"/>
     <copyField source="ss_*" dest="sort_*"/>
     <!-- A random sort field -->
     <dynamicField name="random_*" type="rand" indexed="true" stored="true"/>
     <!-- This field is used to store access information (e.g. node access grants), as opposed to field data -->
-    <dynamicField name="access_*" type="integer" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="access_*" type="integer" indexed="true" stored="true" multiValued="true"/>
 
     <!-- The following causes solr to ignore any fields that don't already match an existing
          field name or dynamic field, rather than reporting them as an error.

--- a/sul-cms-test/schema.xml
+++ b/sul-cms-test/schema.xml
@@ -96,7 +96,7 @@
      and require different update frequencies than the documents they are
      associated with.
     -->
-    <fieldType name="file" keyField="id" defVal="1" stored="false" indexed="false" class="solr.ExternalFileField" />
+    <fieldType name="file" keyField="id" defVal="1" stored="true" indexed="false" class="solr.ExternalFileField" />
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
@@ -423,7 +423,7 @@
 
     <!-- A set of fields to contain text extracted from HTML tag contents which we
          can boost at query time. -->
-    <dynamicField name="tags_*" type="text"   indexed="true" stored="false" omitNorms="true"/>
+    <dynamicField name="tags_*" type="text"   indexed="true" stored="true" omitNorms="true"/>
 
     <!-- For 2 and 3 letter prefix dynamic fields, the 1st letter indicates the data type and
          the last letter is 's' for single valued, 'm' for multi-valued -->
@@ -508,12 +508,12 @@
     <!-- End added fields for Solr 3.4+ -->
 
     <!-- Sortable version of the dynamic string field -->
-    <dynamicField name="sort_*" type="sortString" indexed="true" stored="false"/>
+    <dynamicField name="sort_*" type="sortString" indexed="true" stored="true"/>
     <copyField source="ss_*" dest="sort_*"/>
     <!-- A random sort field -->
     <dynamicField name="random_*" type="rand" indexed="true" stored="true"/>
     <!-- This field is used to store access information (e.g. node access grants), as opposed to field data -->
-    <dynamicField name="access_*" type="integer" indexed="true" stored="false" multiValued="true"/>
+    <dynamicField name="access_*" type="integer" indexed="true" stored="true" multiValued="true"/>
 
     <!-- The following causes solr to ignore any fields that don't already match an existing
          field name or dynamic field, rather than reporting them as an error.


### PR DESCRIPTION
This should allow us to easily rebuild collections (required as part of the solr 7 -> 8 migration) without needing to go back to the original data source (once an initial full reindex is done, of course).