### PR TITLE
Update CIDR collections to use stored fields for all incoming data

### DIFF
--- a/cidr-authorial-prod/schema.xml
+++ b/cidr-authorial-prod/schema.xml
@@ -29,7 +29,7 @@
 
  PERFORMANCE NOTE: this schema includes many optional features and should not
  be used for benchmarking.  To improve performance one could
-  - set stored="false" for all fields possible (esp large fields) when you
+  - set stored="true"  for all fields possible (esp large fields) when you
     only need to search on the field but don't need to return the original
     value.
   - set indexed="false" if you don't need to search on the field, but only
@@ -125,133 +125,133 @@
     <!-- *** This field is used by Sunspot! *** -->
     <field name="id" stored="true" type="string" multiValued="false" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="type" stored="false" type="string" multiValued="true" indexed="true"/>
+    <field name="type" stored="true"  type="string" multiValued="true" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="class_name" stored="false" type="string" multiValued="false" indexed="true"/>
+    <field name="class_name" stored="true"  type="string" multiValued="false" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="text" stored="false" type="string" multiValued="true" indexed="true"/>
+    <field name="text" stored="true"  type="string" multiValued="true" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
     <field name="lat" stored="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
     <field name="lng" stored="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="random_*" stored="false" type="rand" multiValued="false" indexed="true"/>
+    <dynamicField name="random_*" stored="true"  type="rand" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="_local*" stored="false" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="_local*" stored="true"  type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_text" stored="false" type="text" multiValued="true" indexed="true"/>
+    <dynamicField name="*_text" stored="true"  type="text" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_texts" stored="true" type="text" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_b" stored="false" type="boolean" multiValued="false" indexed="true"/>
+    <dynamicField name="*_b" stored="true"  type="boolean" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_bm" stored="false" type="boolean" multiValued="true" indexed="true"/>
+    <dynamicField name="*_bm" stored="true"  type="boolean" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_bs" stored="true" type="boolean" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_bms" stored="true" type="boolean" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_d" stored="false" type="tdate" multiValued="false" indexed="true"/>
+    <dynamicField name="*_d" stored="true"  type="tdate" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dm" stored="false" type="tdate" multiValued="true" indexed="true"/>
+    <dynamicField name="*_dm" stored="true"  type="tdate" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ds" stored="true" type="tdate" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_dms" stored="true" type="tdate" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_e" stored="false" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="*_e" stored="true"  type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_em" stored="false" type="tdouble" multiValued="true" indexed="true"/>
+    <dynamicField name="*_em" stored="true"  type="tdouble" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_es" stored="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ems" stored="true" type="tdouble" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_f" stored="false" type="tfloat" multiValued="false" indexed="true"/>
+    <dynamicField name="*_f" stored="true"  type="tfloat" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_fm" stored="false" type="tfloat" multiValued="true" indexed="true"/>
+    <dynamicField name="*_fm" stored="true"  type="tfloat" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_fs" stored="true" type="tfloat" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_fms" stored="true" type="tfloat" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_i" stored="false" type="tint" multiValued="false" indexed="true"/>
+    <dynamicField name="*_i" stored="true"  type="tint" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_im" stored="false" type="tint" multiValued="true" indexed="true"/>
+    <dynamicField name="*_im" stored="true"  type="tint" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_is" stored="true" type="tint" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ims" stored="true" type="tint" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_l" stored="false" type="tlong" multiValued="false" indexed="true"/>
+    <dynamicField name="*_l" stored="true"  type="tlong" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_lm" stored="false" type="tlong" multiValued="true" indexed="true"/>
+    <dynamicField name="*_lm" stored="true"  type="tlong" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ls" stored="true" type="tlong" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_lms" stored="true" type="tlong" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_s" stored="false" type="string" multiValued="false" indexed="true"/>
+    <dynamicField name="*_s" stored="true"  type="string" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_sm" stored="false" type="string" multiValued="true" indexed="true"/>
+    <dynamicField name="*_sm" stored="true"  type="string" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ss" stored="true" type="string" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_sms" stored="true" type="string" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_it" stored="false" type="tint" multiValued="false" indexed="true"/>
+    <dynamicField name="*_it" stored="true"  type="tint" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_itm" stored="false" type="tint" multiValued="true" indexed="true"/>
+    <dynamicField name="*_itm" stored="true"  type="tint" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_its" stored="true" type="tint" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_itms" stored="true" type="tint" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ft" stored="false" type="tfloat" multiValued="false" indexed="true"/>
+    <dynamicField name="*_ft" stored="true"  type="tfloat" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ftm" stored="false" type="tfloat" multiValued="true" indexed="true"/>
+    <dynamicField name="*_ftm" stored="true"  type="tfloat" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_fts" stored="true" type="tfloat" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ftms" stored="true" type="tfloat" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dt" stored="false" type="tdate" multiValued="false" indexed="true"/>
+    <dynamicField name="*_dt" stored="true"  type="tdate" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dtm" stored="false" type="tdate" multiValued="true" indexed="true"/>
+    <dynamicField name="*_dtm" stored="true"  type="tdate" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_dts" stored="true" type="tdate" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_dtms" stored="true" type="tdate" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_textv" stored="false" termVectors="true" type="text" multiValued="true" indexed="true"/>
+    <dynamicField name="*_textv" stored="true"  termVectors="true" type="text" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_textsv" stored="true" termVectors="true" type="text" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_et" stored="false" termVectors="true" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="*_et" stored="true"  termVectors="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_etm" stored="false" termVectors="true" type="tdouble" multiValued="true" indexed="true"/>
+    <dynamicField name="*_etm" stored="true"  termVectors="true" type="tdouble" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ets" stored="true" termVectors="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_etms" stored="true" termVectors="true" type="tdouble" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <!-- <dynamicField name="*_dr" stored="false" type="daterange" multiValued="false" indexed="true" /> -->
+    <!-- <dynamicField name="*_dr" stored="true"  type="daterange" multiValued="false" indexed="true" /> -->
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <!-- <dynamicField name="*_drm" stored="false" type="daterange" multiValued="true" indexed="true" /> -->
+    <!-- <dynamicField name="*_drm" stored="true"  type="daterange" multiValued="true" indexed="true" /> -->
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <!-- <dynamicField name="*_drs" stored="true" type="daterange" multiValued="false" indexed="true" /> -->
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <!-- <dynamicField name="*_drms" stored="true" type="daterange" multiValued="true" indexed="true" /> -->
 
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
-    <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false" multiValued="false"/>
+    <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="true"  multiValued="false"/>
     <dynamicField name="*_p" type="location" indexed="true" stored="true" multiValued="false"/>
 
-    <dynamicField name="*_ll" stored="false" type="location" multiValued="false" indexed="true"/>
-    <dynamicField name="*_llm" stored="false" type="location" multiValued="true" indexed="true"/>
+    <dynamicField name="*_ll" stored="true"  type="location" multiValued="false" indexed="true"/>
+    <dynamicField name="*_llm" stored="true"  type="location" multiValued="true" indexed="true"/>
     <dynamicField name="*_lls" stored="true" type="location" multiValued="false" indexed="true"/>
     <dynamicField name="*_llms" stored="true" type="location" multiValued="true" indexed="true"/>
-    <field name="textSpell" stored="false" type="textSpell" multiValued="true" indexed="true"/>
+    <field name="textSpell" stored="false"  type="textSpell" multiValued="true" indexed="true"/>
 
     <!-- required by Solr 4 -->
     <field name="_version_" type="string" indexed="true" stored="true" multiValued="false" />

--- a/cidr-authorial-stage/schema.xml
+++ b/cidr-authorial-stage/schema.xml
@@ -29,7 +29,7 @@
 
  PERFORMANCE NOTE: this schema includes many optional features and should not
  be used for benchmarking.  To improve performance one could
-  - set stored="false" for all fields possible (esp large fields) when you
+  - set stored="true"  for all fields possible (esp large fields) when you
     only need to search on the field but don't need to return the original
     value.
   - set indexed="false" if you don't need to search on the field, but only
@@ -125,133 +125,133 @@
     <!-- *** This field is used by Sunspot! *** -->
     <field name="id" stored="true" type="string" multiValued="false" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="type" stored="false" type="string" multiValued="true" indexed="true"/>
+    <field name="type" stored="true"  type="string" multiValued="true" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="class_name" stored="false" type="string" multiValued="false" indexed="true"/>
+    <field name="class_name" stored="true"  type="string" multiValued="false" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
-    <field name="text" stored="false" type="string" multiValued="true" indexed="true"/>
+    <field name="text" stored="true"  type="string" multiValued="true" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
     <field name="lat" stored="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This field is used by Sunspot! *** -->
     <field name="lng" stored="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="random_*" stored="false" type="rand" multiValued="false" indexed="true"/>
+    <dynamicField name="random_*" stored="true"  type="rand" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="_local*" stored="false" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="_local*" stored="true"  type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_text" stored="false" type="text" multiValued="true" indexed="true"/>
+    <dynamicField name="*_text" stored="true"  type="text" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_texts" stored="true" type="text" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_b" stored="false" type="boolean" multiValued="false" indexed="true"/>
+    <dynamicField name="*_b" stored="true"  type="boolean" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_bm" stored="false" type="boolean" multiValued="true" indexed="true"/>
+    <dynamicField name="*_bm" stored="true"  type="boolean" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_bs" stored="true" type="boolean" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_bms" stored="true" type="boolean" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_d" stored="false" type="tdate" multiValued="false" indexed="true"/>
+    <dynamicField name="*_d" stored="true"  type="tdate" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dm" stored="false" type="tdate" multiValued="true" indexed="true"/>
+    <dynamicField name="*_dm" stored="true"  type="tdate" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ds" stored="true" type="tdate" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_dms" stored="true" type="tdate" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_e" stored="false" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="*_e" stored="true"  type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_em" stored="false" type="tdouble" multiValued="true" indexed="true"/>
+    <dynamicField name="*_em" stored="true"  type="tdouble" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_es" stored="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ems" stored="true" type="tdouble" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_f" stored="false" type="tfloat" multiValued="false" indexed="true"/>
+    <dynamicField name="*_f" stored="true"  type="tfloat" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_fm" stored="false" type="tfloat" multiValued="true" indexed="true"/>
+    <dynamicField name="*_fm" stored="true"  type="tfloat" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_fs" stored="true" type="tfloat" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_fms" stored="true" type="tfloat" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_i" stored="false" type="tint" multiValued="false" indexed="true"/>
+    <dynamicField name="*_i" stored="true"  type="tint" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_im" stored="false" type="tint" multiValued="true" indexed="true"/>
+    <dynamicField name="*_im" stored="true"  type="tint" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_is" stored="true" type="tint" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ims" stored="true" type="tint" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_l" stored="false" type="tlong" multiValued="false" indexed="true"/>
+    <dynamicField name="*_l" stored="true"  type="tlong" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_lm" stored="false" type="tlong" multiValued="true" indexed="true"/>
+    <dynamicField name="*_lm" stored="true"  type="tlong" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ls" stored="true" type="tlong" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_lms" stored="true" type="tlong" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_s" stored="false" type="string" multiValued="false" indexed="true"/>
+    <dynamicField name="*_s" stored="true"  type="string" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_sm" stored="false" type="string" multiValued="true" indexed="true"/>
+    <dynamicField name="*_sm" stored="true"  type="string" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ss" stored="true" type="string" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_sms" stored="true" type="string" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_it" stored="false" type="tint" multiValued="false" indexed="true"/>
+    <dynamicField name="*_it" stored="true"  type="tint" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_itm" stored="false" type="tint" multiValued="true" indexed="true"/>
+    <dynamicField name="*_itm" stored="true"  type="tint" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_its" stored="true" type="tint" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_itms" stored="true" type="tint" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ft" stored="false" type="tfloat" multiValued="false" indexed="true"/>
+    <dynamicField name="*_ft" stored="true"  type="tfloat" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_ftm" stored="false" type="tfloat" multiValued="true" indexed="true"/>
+    <dynamicField name="*_ftm" stored="true"  type="tfloat" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_fts" stored="true" type="tfloat" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ftms" stored="true" type="tfloat" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dt" stored="false" type="tdate" multiValued="false" indexed="true"/>
+    <dynamicField name="*_dt" stored="true"  type="tdate" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_dtm" stored="false" type="tdate" multiValued="true" indexed="true"/>
+    <dynamicField name="*_dtm" stored="true"  type="tdate" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_dts" stored="true" type="tdate" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_dtms" stored="true" type="tdate" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_textv" stored="false" termVectors="true" type="text" multiValued="true" indexed="true"/>
+    <dynamicField name="*_textv" stored="true"  termVectors="true" type="text" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_textsv" stored="true" termVectors="true" type="text" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_et" stored="false" termVectors="true" type="tdouble" multiValued="false" indexed="true"/>
+    <dynamicField name="*_et" stored="true"  termVectors="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <dynamicField name="*_etm" stored="false" termVectors="true" type="tdouble" multiValued="true" indexed="true"/>
+    <dynamicField name="*_etm" stored="true"  termVectors="true" type="tdouble" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_ets" stored="true" termVectors="true" type="tdouble" multiValued="false" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <dynamicField name="*_etms" stored="true" termVectors="true" type="tdouble" multiValued="true" indexed="true"/>
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <!-- <dynamicField name="*_dr" stored="false" type="daterange" multiValued="false" indexed="true" /> -->
+    <!-- <dynamicField name="*_dr" stored="true"  type="daterange" multiValued="false" indexed="true" /> -->
     <!-- *** This dynamicField is used by Sunspot! *** -->
-    <!-- <dynamicField name="*_drm" stored="false" type="daterange" multiValued="true" indexed="true" /> -->
+    <!-- <dynamicField name="*_drm" stored="true"  type="daterange" multiValued="true" indexed="true" /> -->
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <!-- <dynamicField name="*_drs" stored="true" type="daterange" multiValued="false" indexed="true" /> -->
     <!-- *** This dynamicField is used by Sunspot! *** -->
     <!-- <dynamicField name="*_drms" stored="true" type="daterange" multiValued="true" indexed="true" /> -->
 
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
-    <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="false" multiValued="false"/>
+    <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="true"  multiValued="false"/>
     <dynamicField name="*_p" type="location" indexed="true" stored="true" multiValued="false"/>
 
-    <dynamicField name="*_ll" stored="false" type="location" multiValued="false" indexed="true"/>
-    <dynamicField name="*_llm" stored="false" type="location" multiValued="true" indexed="true"/>
+    <dynamicField name="*_ll" stored="true"  type="location" multiValued="false" indexed="true"/>
+    <dynamicField name="*_llm" stored="true"  type="location" multiValued="true" indexed="true"/>
     <dynamicField name="*_lls" stored="true" type="location" multiValued="false" indexed="true"/>
     <dynamicField name="*_llms" stored="true" type="location" multiValued="true" indexed="true"/>
-    <field name="textSpell" stored="false" type="textSpell" multiValued="true" indexed="true"/>
+    <field name="textSpell" stored="false"  type="textSpell" multiValued="true" indexed="true"/>
 
     <!-- required by Solr 4 -->
     <field name="_version_" type="string" indexed="true" stored="true" multiValued="false" />

--- a/dig_hcrc_prod/schema.xml
+++ b/dig_hcrc_prod/schema.xml
@@ -16,10 +16,10 @@
  limitations under the License.
 -->
 
-<!--  
+<!--
  This is the Solr schema file. This file should be named "schema.xml" and
  should be in the conf directory under the solr home
- (i.e. ./solr/conf/schema.xml by default) 
+ (i.e. ./solr/conf/schema.xml by default)
  or located where the classloader for the Solr webapp can find it.
 
  This example schema is the recommended starting point for users.
@@ -70,13 +70,13 @@ will increase storage costs.
 default: a value that should be used if no value is specified
 when adding a document.
 -->
-    
+
     <!-- NOTE: this is not a full list of fields in the index; dynamic fields are also used -->
     <field name="id" type="string" indexed="true" stored="true" required="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
     <!-- default, catch all search field -->
     <field name="text" type="text_general" indexed="true" stored="false" multiValued="true"/>
-    
+
     <!-- these display fields are NOT multi-valued -->
     <field name="type" type="string" indexed="true" stored="true" />
     <field name="title" type="text_general" indexed="true" stored="true" />
@@ -87,7 +87,7 @@ when adding a document.
     <field name="publisher" type="text_general" indexed="true" stored="true" />
     <field name="pub_place" type="text_general" indexed="true" stored="true" />
     <field name="edition" type="string" indexed="true" stored="true" />
-    
+
     <!-- these display fields are multi-valued -->
     <field name="author" type="text_general" indexed="true" stored="true" multiValued="true"/>
     <field name="author_nat" type="text_general" indexed="true" stored="true" multiValued="true"/>
@@ -103,15 +103,15 @@ when adding a document.
     <field name="series_vol" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="series_num_vol" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="issue" type="string" indexed="true" stored="true" multiValued="true"/>
-    
+
     <!-- year sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer
 we use 'tint' for faster range-queries. -->
     <field name="year_sort" type="tint" indexed="true" stored="true" multiValued="false"/>
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
-    
+
     <!--<field name="title_specialsort" type="titleSort" indexed="true" stored="true" multiValued="false"/>-->
-    
-    
+
+
     <!-- Dynamic field definitions. If a field name is not found, dynamicFields
 will be used if the name matches any of the patterns.
 RESTRICTION: the glob-like pattern in the name attribute must have
@@ -127,40 +127,40 @@ both match, the first appearing in the schema will be used. -->
     <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/>
     <dynamicField name="*_f" type="float" indexed="true" stored="true"/>
     <dynamicField name="*_d" type="double" indexed="true" stored="true"/>
-    
+
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
-    <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="false"/>
-    
+    <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="true"/>
+
     <dynamicField name="*_dt" type="date" indexed="true" stored="true"/>
     <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
-    
+
     <!-- some trie-coded dynamic fields for faster range queries -->
     <dynamicField name="*_ti" type="tint" indexed="true" stored="true"/>
     <dynamicField name="*_tl" type="tlong" indexed="true" stored="true"/>
     <dynamicField name="*_tf" type="tfloat" indexed="true" stored="true"/>
     <dynamicField name="*_td" type="tdouble" indexed="true" stored="true"/>
     <dynamicField name="*_tdt" type="tdate" indexed="true" stored="true"/>
-    
+
     <dynamicField name="ignored_*" type="ignored" multiValued="true"/>
     <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
-    
+
     <dynamicField name="random_*" type="random" />
-    
+
     <dynamicField name="*_display" type="string" indexed="false" stored="true" multiValued="true" />
     <dynamicField name="*_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <dynamicField name="*_sort" type="alphaOnlySort" indexed="true" stored="false" multiValued="false" />
     <dynamicField name="*_facetSort" type="text_general" indexed="true" stored="false" multiValued="true" />
     <dynamicField name="*_unstem_search" type="text_general" indexed="true" stored="false" multiValued="true" />
     <dynamicField name="*spell" type="text_general" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- uncomment the following to ignore any fields that don't already match an existing
 field name or dynamic field, rather than reporting them as an error.
 alternately, change the type="ignored" to some other type e.g. "text" if you want
 unknown fields indexed and/or stored by default -->
     <!--dynamicField name="*" type="ignored" multiValued="true" /-->
-    
+
   </fields>
-  
+
   <!-- Field to use to determine and enforce document uniqueness.
 Unless this field is marked with required="false", it will be a required field
 -->
@@ -170,16 +170,16 @@ Unless this field is marked with required="false", it will be a required field
 is added to the index. It's used either to index the same field differently,
 or to add multiple fields to the same field for easier/faster searching. -->
   <!-- Copy Fields -->
-  
+
   <!-- unstemmed fields -->
   <copyField source="title" dest="title_unstem_search"/>
   <copyField source="author" dest="author_unstem_search"/>
   <copyField source="corp_author" dest="corp_author_unstem_search"/>
-  
+
   <!-- sort fields -->
   <copyField source="year" dest="year_sort"/>
   <copyField source="title" dest="title_sort"/>
-  
+
   <!-- spellcheck fields -->
   <!-- default spell check; should match fields for default request handler -->
   <!-- it won't work with a copy of a copy field -->
@@ -196,7 +196,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
   <copyField source="state_country" dest="spell"/>
   <copyField source="grade_level_number" dest="spell"/>
   <copyField source="grade_level_group" dest="spell"/>
-  
+
   <copyField source="title" dest="text"/>
   <copyField source="series_title" dest="text"/>
   <copyField source="type" dest="text"/>
@@ -210,7 +210,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
   <copyField source="state_country" dest="text"/>
   <copyField source="grade_level_number" dest="text"/>
   <copyField source="grade_level_group" dest="text"/>
-  
+
   <copyField source="type" dest="type_facet"/>
   <copyField source="author" dest="author_facet"/>
   <copyField source="author_nat" dest="author_nat_facet"/>
@@ -222,30 +222,30 @@ or to add multiple fields to the same field for easier/faster searching. -->
   <copyField source="language" dest="language_facet"/>
   <copyField source="state_country" dest="state_country_facet"/>
   <copyField source="grade_level_group" dest="grade_level_group_facet"/>
-  
+
   <!-- title spell check; should match fields for title request handler -->
   <copyField source="title" dest="title_spell"/>
   <!-- author spell check; should match fields for author request handler -->
   <copyField source="author" dest="author_spell"/>
   <!-- librettist spell check; should match fields for librettist request handler -->
   <copyField source="corp_author" dest="corp_author_spell"/>
-  
+
   <!-- OpenSearch query field should match request handler search fields -->
   <copyField source="title" dest="opensearch_display"/>
   <copyField source="author" dest="opensearch_display"/>
   <copyField source="corp_author" dest="opensearch_display"/>
 
-   
-   <!-- Above, multiple source fields are copied to the [text] field. 
-	  Another way to map multiple source fields to the same 
-	  destination field is to use the dynamic field syntax. 
+
+   <!-- Above, multiple source fields are copied to the [text] field.
+	  Another way to map multiple source fields to the same
+	  destination field is to use the dynamic field syntax.
 	  copyField also supports a maxChars to copy setting.  -->
-	   
+
    <!-- <copyField source="*_t" dest="text" maxChars="3000"/> -->
 
    <!-- copy name to alphaNameSort, a field designed for sorting by name -->
    <!-- <copyField source="name" dest="alphaNameSort"/> -->
- 
+
   <types>
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"
@@ -275,7 +275,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
        - If sortMissingLast="false" and sortMissingFirst="false" (the default),
          then default lucene sorting will be used which places docs without the
          field first in an ascending sort and last in a descending sort.
-    -->    
+    -->
 
     <!--
       Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
@@ -302,7 +302,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime    
+         http://www.w3.org/TR/xmlschema-2/#dateTime
          The trailing "Z" designates UTC time and is mandatory.
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
          All other components are mandatory.
@@ -317,7 +317,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
                NOW/DAY+6MONTHS+3DAYS
                   ... 6 months and 3 days in the future from the start of
                       the current day
-                      
+
          Consult the DateField javadocs for more information.
 
          Note: For faster range queries, consider the tdate type
@@ -333,11 +333,11 @@ or to add multiple fields to the same field for easier/faster searching. -->
 
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
-         to generate pseudo-random orderings of your docs for sorting 
+         to generate pseudo-random orderings of your docs for sorting
          or function purposes.  The ordering is generated based on the field
          name and the version of the index. As long as the index version
          remains unchanged, and the same field name is reused,
-         the ordering of the docs will be consistent.  
+         the ordering of the docs will be consistent.
          If you want different psuedo-random orderings of documents,
          for the same version of the index, use a dynamicField and
          change the field name in the request.
@@ -414,7 +414,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
-                
+
                 />
         <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -430,7 +430,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
-                
+
                 />
         <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -454,7 +454,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
           ignoreCase="true"
           words="lang/stopwords_en.txt"
-          
+
         />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -470,7 +470,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
           ignoreCase="true"
           words="lang/stopwords_en.txt"
-          
+
         />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -494,7 +494,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
           ignoreCase="true"
           words="stopwords_all_lang.txt"
-          
+
         />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -505,7 +505,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- A text field with defaults appropriate for English, plus
 	 aggressive word-splitting and autophrase features enabled.
 	 This field is just like text_en, except it adds
@@ -528,7 +528,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
-                
+
                 />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -541,7 +541,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
-                
+
                 />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -549,8 +549,8 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
-    
+
+
     <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
@@ -565,7 +565,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Just like text_general except it reverses the characters of
 	 each token, to enable more efficient leading wildcard queries. -->
     <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
@@ -598,7 +598,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
          With various TokenFilterFactories to produce a sortable field
          that does not include some properties of the source text
       -->
-    
+
     <fieldType name="alphaOnlySort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
         <!-- KeywordTokenizer does no actual tokenizing, so the entire
@@ -613,13 +613,13 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.TrimFilterFactory" />
         <!-- The PatternReplaceFilter gives you the flexibility to use
              Java Regular expression to replace any sequence of characters
-             matching a pattern with an arbitrary replacement string, 
+             matching a pattern with an arbitrary replacement string,
              which may include back references to portions of the original
              string matched by the pattern.
-             
+
              See the Java Regular Expression documentation for more
              information on pattern and replacement string syntax.
-             
+
              http://java.sun.com/j2se/1.6.0/docs/api/java/util/regex/package-summary.html
           -->
         <filter class="solr.PatternReplaceFilterFactory"
@@ -627,7 +627,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         />
       </analyzer>
     </fieldType>
-   
+
     <fieldtype name="phonetic" stored="false" indexed="true" class="solr.TextField" >
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -641,7 +641,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!--
         The DelimitedPayloadTokenFilter can put payloads on tokens... for example,
         a token of "foo|1.4"  would be indexed as "foo" with a payload of 1.4f
-        Attributes of the DelimitedPayloadTokenFilterFactory : 
+        Attributes of the DelimitedPayloadTokenFilterFactory :
          "delimiter" - a one character delimiter. Default is | (pipe)
 	 "encoder" - how to encode the following value into a playload
 	    float -> org.apache.lucene.analysis.payloads.FloatEncoder,
@@ -661,7 +661,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
       </analyzer>
     </fieldType>
 
-    <!-- 
+    <!--
       Example of using PathHierarchyTokenizerFactory at index time, so
       queries for paths match documents at that path, or in descendent paths
     -->
@@ -673,7 +673,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
 	<tokenizer class="solr.KeywordTokenizerFactory" />
       </analyzer>
     </fieldType>
-    <!-- 
+    <!--
       Example of using PathHierarchyTokenizerFactory at query time, so
       queries for paths match documents at that path, or in ancestor paths
     -->
@@ -687,12 +687,12 @@ or to add multiple fields to the same field for easier/faster searching. -->
     </fieldType>
 
     <!-- since fields of this type are by default not stored or indexed,
-         any data added to them will be ignored outright.  --> 
+         any data added to them will be ignored outright.  -->
     <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
 
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -725,14 +725,14 @@ or to add multiple fields to the same field for easier/faster searching. -->
                              refreshInterval: Number of minutes between each rates fetch (default: 1440, min: 60)
    -->
     <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
-             
+
 
 
    <!-- some examples for different languages (generally ordered by ISO code) -->
 
     <!-- Arabic -->
     <fieldType name="text_ar" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- for any non-arabic -->
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -745,26 +745,26 @@ or to add multiple fields to the same field for easier/faster searching. -->
 
     <!-- Bulgarian -->
     <fieldType name="text_bg" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/> 
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" />
-        <filter class="solr.BulgarianStemFilterFactory"/>       
+        <filter class="solr.BulgarianStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Catalan -->
     <fieldType name="text_ca" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ca.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ca.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>       
+        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- CJK bigram (see text_ja for a Japanese configuration using morphological analysis) -->
     <fieldType name="text_cjk" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -779,27 +779,27 @@ or to add multiple fields to the same field for easier/faster searching. -->
 
     <!-- Czech -->
     <fieldType name="text_cz" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_cz.txt" />
-        <filter class="solr.CzechStemFilterFactory"/>       
+        <filter class="solr.CzechStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Danish -->
     <fieldType name="text_da" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>       
+        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- German -->
     <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" />
@@ -809,10 +809,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="German2"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Greek -->
     <fieldType name="text_el" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- greek specific lowercase for sigma -->
         <filter class="solr.GreekLowerCaseFilterFactory"/>
@@ -820,10 +820,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.GreekStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Spanish -->
     <fieldType name="text_es" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_es.txt" format="snowball" />
@@ -831,17 +831,17 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Spanish"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Basque -->
     <fieldType name="text_eu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_eu.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Basque"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Persian -->
     <fieldType name="text_fa" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -854,10 +854,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fa.txt" />
       </analyzer>
     </fieldType>
-    
+
     <!-- Finnish -->
     <fieldType name="text_fi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fi.txt" format="snowball" />
@@ -865,10 +865,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- less aggressive: <filter class="solr.FinnishLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- French -->
     <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
@@ -879,10 +879,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Irish -->
     <fieldType name="text_ga" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes d', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ga.txt"/>
@@ -893,10 +893,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.SnowballPorterFilterFactory" language="Irish"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Galician -->
     <fieldType name="text_gl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_gl.txt" />
@@ -904,10 +904,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- less aggressive: <filter class="solr.GalicianMinimalStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Hindi -->
     <fieldType name="text_hi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <!-- normalizes unicode representation -->
@@ -918,31 +918,31 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.HindiStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Hungarian -->
     <fieldType name="text_hu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hu.txt" format="snowball" />
         <filter class="solr.SnowballPorterFilterFactory" language="Hungarian"/>
-        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->   
+        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Armenian -->
     <fieldType name="text_hy" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hy.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Armenian"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Indonesian -->
     <fieldType name="text_id" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_id.txt" />
@@ -950,10 +950,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Italian -->
     <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_it.txt"/>
@@ -963,11 +963,11 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Italian"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Japanese using morphological analysis (see text_cjk for a configuration using bigramming)
 
          NOTE: If you want to optimize search for precision, use default operator AND in your query
-         parser config with <solrQueryParser defaultOperator="AND"/> further down in this file.  Use 
+         parser config with <solrQueryParser defaultOperator="AND"/> further down in this file.  Use
          OR if you would like to optimize for recall (default).
     -->
     <fieldType name="text_ja" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="false">
@@ -1016,20 +1016,20 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Latvian -->
     <fieldType name="text_lv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_lv.txt" />
         <filter class="solr.LatvianStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Dutch -->
     <fieldType name="text_nl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_nl.txt" format="snowball" />
@@ -1037,10 +1037,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.SnowballPorterFilterFactory" language="Dutch"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Norwegian -->
     <fieldType name="text_no" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_no.txt" format="snowball" />
@@ -1049,10 +1049,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- singular/plural: <filter class="solr.NorwegianMinimalStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Portuguese -->
     <fieldType name="text_pt" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_pt.txt" format="snowball" />
@@ -1062,20 +1062,20 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- most aggressive: <filter class="solr.PortugueseStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Romanian -->
     <fieldType name="text_ro" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ro.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Romanian"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Russian -->
     <fieldType name="text_ru" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ru.txt" format="snowball" />
@@ -1083,10 +1083,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- less aggressive: <filter class="solr.RussianLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Swedish -->
     <fieldType name="text_sv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_sv.txt" format="snowball" />
@@ -1094,19 +1094,19 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- less aggressive: <filter class="solr.SwedishLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Thai -->
     <fieldType name="text_th" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.ThaiTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_th.txt" />
       </analyzer>
     </fieldType>
-    
+
     <!-- Turkish -->
     <fieldType name="text_tr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.TurkishLowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_tr.txt" />
@@ -1118,17 +1118,17 @@ or to add multiple fields to the same field for easier/faster searching. -->
     <analyzer>
       <tokenizer class="solr.KeywordTokenizerFactory"/>
       <filter class="solr.LengthFilterFactory" min="1" max="12" />
-      <filter class="solr.SynonymFilterFactory" 
-        synonyms="feastMonth_attributes.txt" 
+      <filter class="solr.SynonymFilterFactory"
+        synonyms="feastMonth_attributes.txt"
         ignoreCase="false" expand="false"/>
     </analyzer>
   </fieldType>-->
 
  </types>
-  
+
   <!-- Similarity is the scoring routine for each document vs. a query.
-       A custom Similarity or SimilarityFactory may be specified here, but 
-       the default is fine for most applications.  
+       A custom Similarity or SimilarityFactory may be specified here, but
+       the default is fine for most applications.
        For more info: http://wiki.apache.org/solr/SchemaXml#Similarity
     -->
   <!--

--- a/dig_hcrc_test/schema.xml
+++ b/dig_hcrc_test/schema.xml
@@ -16,10 +16,10 @@
  limitations under the License.
 -->
 
-<!--  
+<!--
  This is the Solr schema file. This file should be named "schema.xml" and
  should be in the conf directory under the solr home
- (i.e. ./solr/conf/schema.xml by default) 
+ (i.e. ./solr/conf/schema.xml by default)
  or located where the classloader for the Solr webapp can find it.
 
  This example schema is the recommended starting point for users.
@@ -70,13 +70,13 @@ will increase storage costs.
 default: a value that should be used if no value is specified
 when adding a document.
 -->
-    
+
     <!-- NOTE: this is not a full list of fields in the index; dynamic fields are also used -->
     <field name="id" type="string" indexed="true" stored="true" required="true"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
     <!-- default, catch all search field -->
     <field name="text" type="text_general" indexed="true" stored="false" multiValued="true"/>
-    
+
     <!-- these display fields are NOT multi-valued -->
     <field name="type" type="string" indexed="true" stored="true" />
     <field name="title" type="text_general" indexed="true" stored="true" />
@@ -87,7 +87,7 @@ when adding a document.
     <field name="publisher" type="text_general" indexed="true" stored="true" />
     <field name="pub_place" type="text_general" indexed="true" stored="true" />
     <field name="edition" type="string" indexed="true" stored="true" />
-    
+
     <!-- these display fields are multi-valued -->
     <field name="author" type="text_general" indexed="true" stored="true" multiValued="true"/>
     <field name="author_nat" type="text_general" indexed="true" stored="true" multiValued="true"/>
@@ -103,15 +103,15 @@ when adding a document.
     <field name="series_vol" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="series_num_vol" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="issue" type="string" indexed="true" stored="true" multiValued="true"/>
-    
+
     <!-- year sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer
 we use 'tint' for faster range-queries. -->
     <field name="year_sort" type="tint" indexed="true" stored="true" multiValued="false"/>
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
-    
+
     <!--<field name="title_specialsort" type="titleSort" indexed="true" stored="true" multiValued="false"/>-->
-    
-    
+
+
     <!-- Dynamic field definitions. If a field name is not found, dynamicFields
 will be used if the name matches any of the patterns.
 RESTRICTION: the glob-like pattern in the name attribute must have
@@ -127,13 +127,13 @@ both match, the first appearing in the schema will be used. -->
     <dynamicField name="*_b" type="boolean" indexed="true" stored="true"/>
     <dynamicField name="*_f" type="float" indexed="true" stored="true"/>
     <dynamicField name="*_d" type="double" indexed="true" stored="true"/>
-    
+
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
-    <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="false"/>
-    
+    <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="true"/>
+
     <dynamicField name="*_dt" type="date" indexed="true" stored="true"/>
     <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
-    
+
     <!-- some trie-coded dynamic fields for faster range queries -->
     <dynamicField name="*_ti" type="tint" indexed="true" stored="true"/>
     <dynamicField name="*_tl" type="tlong" indexed="true" stored="true"/>
@@ -143,24 +143,24 @@ both match, the first appearing in the schema will be used. -->
 
     <dynamicField name="ignored_*" type="ignored" multiValued="true"/>
     <dynamicField name="attr_*" type="text_general" indexed="true" stored="true" multiValued="true"/>
-    
+
     <dynamicField name="random_*" type="random" />
-    
+
     <dynamicField name="*_display" type="string" indexed="false" stored="true" multiValued="true" />
     <dynamicField name="*_facet" type="string" indexed="true" stored="false" multiValued="true" />
     <dynamicField name="*_sort" type="alphaOnlySort" indexed="true" stored="false" multiValued="false" />
     <dynamicField name="*_facetSort" type="text_general" indexed="true" stored="false" multiValued="true" />
     <dynamicField name="*_unstem_search" type="text_general" indexed="true" stored="false" multiValued="true" />
     <dynamicField name="*spell" type="text_general" indexed="true" stored="false" multiValued="true" />
-    
+
     <!-- uncomment the following to ignore any fields that don't already match an existing
 field name or dynamic field, rather than reporting them as an error.
 alternately, change the type="ignored" to some other type e.g. "text" if you want
 unknown fields indexed and/or stored by default -->
     <!--dynamicField name="*" type="ignored" multiValued="true" /-->
-    
+
   </fields>
-  
+
   <!-- Field to use to determine and enforce document uniqueness.
 Unless this field is marked with required="false", it will be a required field
 -->
@@ -170,16 +170,16 @@ Unless this field is marked with required="false", it will be a required field
 is added to the index. It's used either to index the same field differently,
 or to add multiple fields to the same field for easier/faster searching. -->
   <!-- Copy Fields -->
-  
+
   <!-- unstemmed fields -->
   <copyField source="title" dest="title_unstem_search"/>
   <copyField source="author" dest="author_unstem_search"/>
   <copyField source="corp_author" dest="corp_author_unstem_search"/>
-  
+
   <!-- sort fields -->
   <copyField source="year" dest="year_sort"/>
   <copyField source="title" dest="title_sort"/>
-  
+
   <!-- spellcheck fields -->
   <!-- default spell check; should match fields for default request handler -->
   <!-- it won't work with a copy of a copy field -->
@@ -196,7 +196,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
   <copyField source="state_country" dest="spell"/>
   <copyField source="grade_level_number" dest="spell"/>
   <copyField source="grade_level_group" dest="spell"/>
-  
+
   <copyField source="title" dest="text"/>
   <copyField source="series_title" dest="text"/>
   <copyField source="type" dest="text"/>
@@ -210,7 +210,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
   <copyField source="state_country" dest="text"/>
   <copyField source="grade_level_number" dest="text"/>
   <copyField source="grade_level_group" dest="text"/>
-  
+
   <copyField source="type" dest="type_facet"/>
   <copyField source="author" dest="author_facet"/>
   <copyField source="author_nat" dest="author_nat_facet"/>
@@ -222,30 +222,30 @@ or to add multiple fields to the same field for easier/faster searching. -->
   <copyField source="language" dest="language_facet"/>
   <copyField source="state_country" dest="state_country_facet"/>
   <copyField source="grade_level_group" dest="grade_level_group_facet"/>
-  
+
   <!-- title spell check; should match fields for title request handler -->
   <copyField source="title" dest="title_spell"/>
   <!-- author spell check; should match fields for author request handler -->
   <copyField source="author" dest="author_spell"/>
   <!-- librettist spell check; should match fields for librettist request handler -->
   <copyField source="corp_author" dest="corp_author_spell"/>
-  
+
   <!-- OpenSearch query field should match request handler search fields -->
   <copyField source="title" dest="opensearch_display"/>
   <copyField source="author" dest="opensearch_display"/>
   <copyField source="corp_author" dest="opensearch_display"/>
 
-   
-   <!-- Above, multiple source fields are copied to the [text] field. 
-	  Another way to map multiple source fields to the same 
-	  destination field is to use the dynamic field syntax. 
+
+   <!-- Above, multiple source fields are copied to the [text] field.
+	  Another way to map multiple source fields to the same
+	  destination field is to use the dynamic field syntax.
 	  copyField also supports a maxChars to copy setting.  -->
-	   
+
    <!-- <copyField source="*_t" dest="text" maxChars="3000"/> -->
 
    <!-- copy name to alphaNameSort, a field designed for sorting by name -->
    <!-- <copyField source="name" dest="alphaNameSort"/> -->
- 
+
   <types>
     <!-- field type definitions. The "name" attribute is
        just a label to be used by field definitions.  The "class"
@@ -275,7 +275,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
        - If sortMissingLast="false" and sortMissingFirst="false" (the default),
          then default lucene sorting will be used which places docs without the
          field first in an ascending sort and last in a descending sort.
-    -->    
+    -->
 
     <!--
       Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
@@ -302,7 +302,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
-         http://www.w3.org/TR/xmlschema-2/#dateTime    
+         http://www.w3.org/TR/xmlschema-2/#dateTime
          The trailing "Z" designates UTC time and is mandatory.
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
          All other components are mandatory.
@@ -317,7 +317,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
                NOW/DAY+6MONTHS+3DAYS
                   ... 6 months and 3 days in the future from the start of
                       the current day
-                      
+
          Consult the DateField javadocs for more information.
 
          Note: For faster range queries, consider the tdate type
@@ -333,11 +333,11 @@ or to add multiple fields to the same field for easier/faster searching. -->
 
     <!-- The "RandomSortField" is not used to store or search any
          data.  You can declare fields of this type it in your schema
-         to generate pseudo-random orderings of your docs for sorting 
+         to generate pseudo-random orderings of your docs for sorting
          or function purposes.  The ordering is generated based on the field
          name and the version of the index. As long as the index version
          remains unchanged, and the same field name is reused,
-         the ordering of the docs will be consistent.  
+         the ordering of the docs will be consistent.
          If you want different psuedo-random orderings of documents,
          for the same version of the index, use a dynamicField and
          change the field name in the request.
@@ -414,7 +414,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
-                
+
                 />
         <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -430,7 +430,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
-                
+
                 />
         <filter class="solr.LowerCaseFilterFactory"/>
 	<filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -454,7 +454,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
           ignoreCase="true"
           words="lang/stopwords_en.txt"
-          
+
         />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -470,7 +470,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
           ignoreCase="true"
           words="lang/stopwords_en.txt"
-          
+
         />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -494,7 +494,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
           ignoreCase="true"
           words="stopwords_all_lang.txt"
-          
+
         />
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -505,7 +505,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- A text field with defaults appropriate for English, plus
 	 aggressive word-splitting and autophrase features enabled.
 	 This field is just like text_en, except it adds
@@ -528,7 +528,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
-                
+
                 />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -541,7 +541,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt"
-                
+
                 />
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -549,8 +549,8 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
-    
+
+
     <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
@@ -565,7 +565,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Just like text_general except it reverses the characters of
 	 each token, to enable more efficient leading wildcard queries. -->
     <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
@@ -598,7 +598,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
          With various TokenFilterFactories to produce a sortable field
          that does not include some properties of the source text
       -->
-    
+
     <fieldType name="alphaOnlySort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
       <analyzer>
         <!-- KeywordTokenizer does no actual tokenizing, so the entire
@@ -613,13 +613,13 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.TrimFilterFactory" />
         <!-- The PatternReplaceFilter gives you the flexibility to use
              Java Regular expression to replace any sequence of characters
-             matching a pattern with an arbitrary replacement string, 
+             matching a pattern with an arbitrary replacement string,
              which may include back references to portions of the original
              string matched by the pattern.
-             
+
              See the Java Regular Expression documentation for more
              information on pattern and replacement string syntax.
-             
+
              http://java.sun.com/j2se/1.6.0/docs/api/java/util/regex/package-summary.html
           -->
         <filter class="solr.PatternReplaceFilterFactory"
@@ -627,7 +627,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         />
       </analyzer>
     </fieldType>
-   
+
     <fieldtype name="phonetic" stored="false" indexed="true" class="solr.TextField" >
       <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
@@ -641,7 +641,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!--
         The DelimitedPayloadTokenFilter can put payloads on tokens... for example,
         a token of "foo|1.4"  would be indexed as "foo" with a payload of 1.4f
-        Attributes of the DelimitedPayloadTokenFilterFactory : 
+        Attributes of the DelimitedPayloadTokenFilterFactory :
          "delimiter" - a one character delimiter. Default is | (pipe)
 	 "encoder" - how to encode the following value into a playload
 	    float -> org.apache.lucene.analysis.payloads.FloatEncoder,
@@ -661,7 +661,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
       </analyzer>
     </fieldType>
 
-    <!-- 
+    <!--
       Example of using PathHierarchyTokenizerFactory at index time, so
       queries for paths match documents at that path, or in descendent paths
     -->
@@ -673,7 +673,7 @@ or to add multiple fields to the same field for easier/faster searching. -->
 	<tokenizer class="solr.KeywordTokenizerFactory" />
       </analyzer>
     </fieldType>
-    <!-- 
+    <!--
       Example of using PathHierarchyTokenizerFactory at query time, so
       queries for paths match documents at that path, or in ancestor paths
     -->
@@ -687,12 +687,12 @@ or to add multiple fields to the same field for easier/faster searching. -->
     </fieldType>
 
     <!-- since fields of this type are by default not stored or indexed,
-         any data added to them will be ignored outright.  --> 
+         any data added to them will be ignored outright.  -->
     <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
 
     <!-- This point type indexes the coordinates as separate fields (subFields)
       If subFieldType is defined, it references a type, and a dynamic field
-      definition is created matching *___<typename>.  Alternately, if 
+      definition is created matching *___<typename>.  Alternately, if
       subFieldSuffix is defined, that is used to create the subFields.
       Example: if subFieldType="double", then the coordinates would be
         indexed in fields myloc_0___double,myloc_1___double.
@@ -725,14 +725,14 @@ or to add multiple fields to the same field for easier/faster searching. -->
                              refreshInterval: Number of minutes between each rates fetch (default: 1440, min: 60)
    -->
     <fieldType name="currency" class="solr.CurrencyField" precisionStep="8" defaultCurrency="USD" currencyConfig="currency.xml" />
-             
+
 
 
    <!-- some examples for different languages (generally ordered by ISO code) -->
 
     <!-- Arabic -->
     <fieldType name="text_ar" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- for any non-arabic -->
         <filter class="solr.LowerCaseFilterFactory"/>
@@ -745,26 +745,26 @@ or to add multiple fields to the same field for easier/faster searching. -->
 
     <!-- Bulgarian -->
     <fieldType name="text_bg" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
-        <tokenizer class="solr.StandardTokenizerFactory"/> 
+      <analyzer>
+        <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_bg.txt" />
-        <filter class="solr.BulgarianStemFilterFactory"/>       
+        <filter class="solr.BulgarianStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Catalan -->
     <fieldType name="text_ca" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ca.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ca.txt" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>       
+        <filter class="solr.SnowballPorterFilterFactory" language="Catalan"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- CJK bigram (see text_ja for a Japanese configuration using morphological analysis) -->
     <fieldType name="text_cjk" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -779,27 +779,27 @@ or to add multiple fields to the same field for easier/faster searching. -->
 
     <!-- Czech -->
     <fieldType name="text_cz" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_cz.txt" />
-        <filter class="solr.CzechStemFilterFactory"/>       
+        <filter class="solr.CzechStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Danish -->
     <fieldType name="text_da" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_da.txt" format="snowball" />
-        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>       
+        <filter class="solr.SnowballPorterFilterFactory" language="Danish"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- German -->
     <fieldType name="text_de" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_de.txt" format="snowball" />
@@ -809,10 +809,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="German2"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Greek -->
     <fieldType name="text_el" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- greek specific lowercase for sigma -->
         <filter class="solr.GreekLowerCaseFilterFactory"/>
@@ -820,10 +820,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.GreekStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Spanish -->
     <fieldType name="text_es" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_es.txt" format="snowball" />
@@ -831,17 +831,17 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Spanish"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Basque -->
     <fieldType name="text_eu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_eu.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Basque"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Persian -->
     <fieldType name="text_fa" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
@@ -854,10 +854,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fa.txt" />
       </analyzer>
     </fieldType>
-    
+
     <!-- Finnish -->
     <fieldType name="text_fi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_fi.txt" format="snowball" />
@@ -865,10 +865,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- less aggressive: <filter class="solr.FinnishLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- French -->
     <fieldType name="text_fr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_fr.txt"/>
@@ -879,10 +879,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="French"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Irish -->
     <fieldType name="text_ga" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes d', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_ga.txt"/>
@@ -893,10 +893,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.SnowballPorterFilterFactory" language="Irish"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Galician -->
     <fieldType name="text_gl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_gl.txt" />
@@ -904,10 +904,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- less aggressive: <filter class="solr.GalicianMinimalStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Hindi -->
     <fieldType name="text_hi" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <!-- normalizes unicode representation -->
@@ -918,31 +918,31 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.HindiStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Hungarian -->
     <fieldType name="text_hu" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hu.txt" format="snowball" />
         <filter class="solr.SnowballPorterFilterFactory" language="Hungarian"/>
-        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->   
+        <!-- less aggressive: <filter class="solr.HungarianLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Armenian -->
     <fieldType name="text_hy" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_hy.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Armenian"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Indonesian -->
     <fieldType name="text_id" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_id.txt" />
@@ -950,10 +950,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.IndonesianStemFilterFactory" stemDerivational="true"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Italian -->
     <fieldType name="text_it" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <!-- removes l', etc -->
         <filter class="solr.ElisionFilterFactory" ignoreCase="true" articles="lang/contractions_it.txt"/>
@@ -963,11 +963,11 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- more aggressive: <filter class="solr.SnowballPorterFilterFactory" language="Italian"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Japanese using morphological analysis (see text_cjk for a configuration using bigramming)
 
          NOTE: If you want to optimize search for precision, use default operator AND in your query
-         parser config with <solrQueryParser defaultOperator="AND"/> further down in this file.  Use 
+         parser config with <solrQueryParser defaultOperator="AND"/> further down in this file.  Use
          OR if you would like to optimize for recall (default).
     -->
     <fieldType name="text_ja" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="false">
@@ -1016,20 +1016,20 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Latvian -->
     <fieldType name="text_lv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_lv.txt" />
         <filter class="solr.LatvianStemFilterFactory"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Dutch -->
     <fieldType name="text_nl" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_nl.txt" format="snowball" />
@@ -1037,10 +1037,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <filter class="solr.SnowballPorterFilterFactory" language="Dutch"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Norwegian -->
     <fieldType name="text_no" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_no.txt" format="snowball" />
@@ -1049,10 +1049,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- singular/plural: <filter class="solr.NorwegianMinimalStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Portuguese -->
     <fieldType name="text_pt" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_pt.txt" format="snowball" />
@@ -1062,20 +1062,20 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- most aggressive: <filter class="solr.PortugueseStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Romanian -->
     <fieldType name="text_ro" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ro.txt" />
         <filter class="solr.SnowballPorterFilterFactory" language="Romanian"/>
       </analyzer>
     </fieldType>
-    
+
     <!-- Russian -->
     <fieldType name="text_ru" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_ru.txt" format="snowball" />
@@ -1083,10 +1083,10 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- less aggressive: <filter class="solr.RussianLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Swedish -->
     <fieldType name="text_sv" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_sv.txt" format="snowball" />
@@ -1094,19 +1094,19 @@ or to add multiple fields to the same field for easier/faster searching. -->
         <!-- less aggressive: <filter class="solr.SwedishLightStemFilterFactory"/> -->
       </analyzer>
     </fieldType>
-    
+
     <!-- Thai -->
     <fieldType name="text_th" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.ThaiTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="lang/stopwords_th.txt" />
       </analyzer>
     </fieldType>
-    
+
     <!-- Turkish -->
     <fieldType name="text_tr" class="solr.TextField" positionIncrementGap="100">
-      <analyzer> 
+      <analyzer>
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.TurkishLowerCaseFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="false" words="lang/stopwords_tr.txt" />
@@ -1118,17 +1118,17 @@ or to add multiple fields to the same field for easier/faster searching. -->
     <analyzer>
       <tokenizer class="solr.KeywordTokenizerFactory"/>
       <filter class="solr.LengthFilterFactory" min="1" max="12" />
-      <filter class="solr.SynonymFilterFactory" 
-        synonyms="feastMonth_attributes.txt" 
+      <filter class="solr.SynonymFilterFactory"
+        synonyms="feastMonth_attributes.txt"
         ignoreCase="false" expand="false"/>
     </analyzer>
   </fieldType>-->
 
  </types>
-  
+
   <!-- Similarity is the scoring routine for each document vs. a query.
-       A custom Similarity or SimilarityFactory may be specified here, but 
-       the default is fine for most applications.  
+       A custom Similarity or SimilarityFactory may be specified here, but
+       the default is fine for most applications.
        For more info: http://wiki.apache.org/solr/SchemaXml#Similarity
     -->
   <!--


### PR DESCRIPTION
This should allow us to easily rebuild collections (required as part of the solr 7 -> 8 migration) without needing to go back to the original data source (once an initial full reindex is done, of course).