### PR TITLE
Add arclight field definition for _root_

### DIFF
--- a/arclight-demo/schema.xml
+++ b/arclight-demo/schema.xml
@@ -457,6 +457,7 @@
 
    <!-- NOTE: this is not a full list of fields in the index; dynamic fields are also used -->
    <field name="id" type="string" indexed="true" stored="true" required="true" />
+   <field name="_root_" type="string" indexed="true" stored="true"/>
    <field name="_version_" type="long" indexed="true" stored="true" multiValued="false" />
    <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
    <!-- default, catch all search field -->

--- a/arclight-prod/schema.xml
+++ b/arclight-prod/schema.xml
@@ -457,6 +457,7 @@
 
    <!-- NOTE: this is not a full list of fields in the index; dynamic fields are also used -->
    <field name="id" type="string" indexed="true" stored="true" required="true" />
+   <field name="_root_" type="string" indexed="true" stored="true"/>
    <field name="_version_" type="long" indexed="true" stored="true" multiValued="false" />
    <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
    <!-- default, catch all search field -->


### PR DESCRIPTION
Fixes:

> org.apache.solr.common.SolrException: Unable to index docs with children: the schema must include definitions for both a uniqueKey field and the '_root_' field, using the exact same fieldType
