### PR TITLE
Backout auto hash and only rely on dynamic field name

### DIFF
--- a/kurma-earthworks-v1-stage/schema.xml
+++ b/kurma-earthworks-v1-stage/schema.xml
@@ -23,6 +23,7 @@
     <dynamicField name="*_s"    type="string"  stored="true"  indexed="true"/>
     <dynamicField name="*_ss"   type="string"  stored="true"  indexed="false"/>
     <dynamicField name="*_si"   type="string"  stored="false" indexed="true"/>
+    <dynamicField name="*_ssi"  type="string"  stored="true"  indexed="true" omitNorms="true" />
     <dynamicField name="*_sim"  type="string"  stored="false" indexed="true" multiValued="true" />
     <dynamicField name="*_sm"   type="string"  stored="true"  indexed="true" multiValued="true" />
     <dynamicField name="*_url"  type="string"  stored="true"  indexed="false"/>

--- a/kurma-earthworks-v1-stage/schema.xml
+++ b/kurma-earthworks-v1-stage/schema.xml
@@ -23,7 +23,6 @@
     <dynamicField name="*_s"    type="string"  stored="true"  indexed="true"/>
     <dynamicField name="*_ss"   type="string"  stored="true"  indexed="false"/>
     <dynamicField name="*_si"   type="string"  stored="false" indexed="true"/>
-    <dynamicField name="*_ssi"  type="string"  stored="true"  indexed="true" omitNorms="true" />
     <dynamicField name="*_sim"  type="string"  stored="false" indexed="true" multiValued="true" />
     <dynamicField name="*_sm"   type="string"  stored="true"  indexed="true" multiValued="true" />
     <dynamicField name="*_url"  type="string"  stored="true"  indexed="false"/>

--- a/kurma-earthworks-v1-stage/solrconfig.xml
+++ b/kurma-earthworks-v1-stage/solrconfig.xml
@@ -38,24 +38,7 @@
     </autoCommit>
   </updateHandler>
 
-  <updateRequestProcessorChain name="add_hashed_id">
-    <processor class="solr.processor.SignatureUpdateProcessorFactory">
-      <bool name="enabled">true</bool>
-      <str name="signatureField">hashed_id_ssi</str>
-      <bool name="overwriteDupes">false</bool>
-      <str name="fields">layer_slug_s</str>
-      <str name="signatureClass">solr.processor.Lookup3Signature</str>
-    </processor>
 
-    <processor class="solr.LogUpdateProcessorFactory" />
-    <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>
-
-  <requestHandler name="/update" class="solr.UpdateRequestHandler">
-    <lst name="defaults">
-      <str name="update.chain">add_hashed_id</str>
-    </lst>
-  </requestHandler>
 
   <!-- Required for Solr Cloud on sul-solr -->
   <requestHandler name="/replication" class="solr.ReplicationHandler" startup="lazy" />

--- a/searchworks-dev/solrconfig.xml
+++ b/searchworks-dev/solrconfig.xml
@@ -222,26 +222,9 @@
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
 
-  <updateRequestProcessorChain name="add_hashed_id">
-    <processor class="solr.processor.SignatureUpdateProcessorFactory">
-      <bool name="enabled">true</bool>
-      <str name="signatureField">hashed_id_ssi</str>
-      <bool name="overwriteDupes">false</bool>
-      <str name="fields">id</str>
-      <str name="signatureClass">solr.processor.Lookup3Signature</str>
-    </processor>
-
-    <processor class="solr.LogUpdateProcessorFactory" />
-    <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>
-
   <requestHandler name="standard" class="solr.StandardRequestHandler" />
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
-  <requestHandler name="/update" class="solr.UpdateRequestHandler">
-    <lst name="defaults">
-      <str name="update.chain">add_hashed_id</str>
-    </lst>
-  </requestHandler>
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
 
   <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
     <lst name="invariants">

--- a/searchworks-gryphon-search-preview/solrconfig.xml
+++ b/searchworks-gryphon-search-preview/solrconfig.xml
@@ -215,26 +215,9 @@
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
 
-  <updateRequestProcessorChain name="add_hashed_id">
-    <processor class="solr.processor.SignatureUpdateProcessorFactory">
-      <bool name="enabled">true</bool>
-      <str name="signatureField">hashed_id_ssi</str>
-      <bool name="overwriteDupes">false</bool>
-      <str name="fields">id</str>
-      <str name="signatureClass">solr.processor.Lookup3Signature</str>
-    </processor>
-
-    <processor class="solr.LogUpdateProcessorFactory" />
-    <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>
-
   <requestHandler name="standard" class="solr.StandardRequestHandler" />
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
-  <requestHandler name="/update" class="solr.UpdateRequestHandler">
-    <lst name="defaults">
-      <str name="update.chain">add_hashed_id</str>
-    </lst>
-  </requestHandler>
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
 
   <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
     <lst name="invariants">

--- a/searchworks-morison-dev/solrconfig.xml
+++ b/searchworks-morison-dev/solrconfig.xml
@@ -222,26 +222,9 @@
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
 
-  <updateRequestProcessorChain name="add_hashed_id">
-    <processor class="solr.processor.SignatureUpdateProcessorFactory">
-      <bool name="enabled">true</bool>
-      <str name="signatureField">hashed_id_ssi</str>
-      <bool name="overwriteDupes">false</bool>
-      <str name="fields">id</str>
-      <str name="signatureClass">solr.processor.Lookup3Signature</str>
-    </processor>
-
-    <processor class="solr.LogUpdateProcessorFactory" />
-    <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>
-
   <requestHandler name="standard" class="solr.StandardRequestHandler" />
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
-  <requestHandler name="/update" class="solr.UpdateRequestHandler">
-    <lst name="defaults">
-      <str name="update.chain">add_hashed_id</str>
-    </lst>
-  </requestHandler>
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
 
   <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
     <lst name="invariants">

--- a/searchworks-morison/solrconfig.xml
+++ b/searchworks-morison/solrconfig.xml
@@ -222,26 +222,9 @@
     <requestParsers enableRemoteStreaming="true" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
 
-  <updateRequestProcessorChain name="add_hashed_id">
-    <processor class="solr.processor.SignatureUpdateProcessorFactory">
-      <bool name="enabled">true</bool>
-      <str name="signatureField">hashed_id_ssi</str>
-      <bool name="overwriteDupes">false</bool>
-      <str name="fields">id</str>
-      <str name="signatureClass">solr.processor.Lookup3Signature</str>
-    </processor>
-
-    <processor class="solr.LogUpdateProcessorFactory" />
-    <processor class="solr.RunUpdateProcessorFactory" />
-  </updateRequestProcessorChain>
-
   <requestHandler name="standard" class="solr.StandardRequestHandler" />
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
-  <requestHandler name="/update" class="solr.UpdateRequestHandler">
-    <lst name="defaults">
-      <str name="update.chain">add_hashed_id</str>
-    </lst>
-  </requestHandler>
+  <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
 
   <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
     <lst name="invariants">


### PR DESCRIPTION
Rather than have solr generate this automatically, we are just going to dynamically generate them using MD5