### PR TITLE
Improve search handling for non-LC call numbers

### DIFF
--- a/searchworks-dev/schema.xml
+++ b/searchworks-dev/schema.xml
@@ -661,8 +661,10 @@
     <!-- field designed for LC call number searching -->
     <fieldType name="callnum_ws" class="solr.TextField" omitNorms="true" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer type="index">
-        <!-- LC: no space between class letters and digits; normalize to " ." before first cutter, no leading space -->
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^ *([A-Za-z]{1,3}) ?(\d{1,4}(\.\d+)?) ?\.?([A-Za-z]\d+)" replacement="$1$2 .$4"/>
+        <!-- LC: no space between class letters and digits, no leading space -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^ *([A-Za-z]{1,3}) +(\d{1,4})" replacement="$1$2" />
+        <!-- LC: normalize to " ." before first cutter or first letter of cutter (could be preceded by " ." "." " " or nothing) -->
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([A-Za-z]{1,3}\d{1,4}(\.\d+)?) *\.?([A-Za-z](\d+)?)" replacement="$1 .$3" />
         <!-- LC: add space between first cutter letter and its digits to allow matching on first cutter letter only -->
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([A-Za-z]{1,3}\d{1,4}(\.\d+)? \.([A-Za-z]))(\d+)" replacement="$1 $4"/>
         <!-- prepend yyyy to string so searches can be left anchored -->
@@ -673,7 +675,7 @@
       <!-- Note that the query string could be a partial call number, so we can't combine all patterns -->
       <analyzer type="query">
         <!-- LC: no space between class letters and digits, no leading space -->
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^ *([A-Za-z]{1,3}) *(\d{1,4})" replacement="$1$2" />
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^ *([A-Za-z]{1,3}) +(\d{1,4})" replacement="$1$2" />
         <!-- LC: normalize to " ." before first cutter or first letter of cutter (could be preceded by " ." "." " " or nothing) -->
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^([A-Za-z]{1,3}\d{1,4}(\.\d+)?) *\.?([A-Za-z](\d+)?)" replacement="$1 .$3" />
         <!-- LC: add space between first cutter letter and its digits to allow matching on first cutter letter only -->


### PR DESCRIPTION
This alters the index and query time analysis for the call number
search field to handle some special non-LC call numbers, which
makes it easier to discover these items with a call number search.

Ref https://github.com/sul-dlss/searchworks_traject_indexer/issues/773
