### PR TITLE
argo_xxx: descriptive_* fields replace all_text_*

### DIFF
--- a/argo_prod/schema.xml
+++ b/argo_prod/schema.xml
@@ -11,9 +11,6 @@
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
-    <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
-    <field name="all_text_timv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
     <!-- string (_s...) -->

--- a/argo_prod/solrconfig.xml
+++ b/argo_prod/solrconfig.xml
@@ -32,11 +32,15 @@
 
       <str name="qf">
         id
-        all_text_timv
+        descriptive_tiv
+        descriptive_text_nostem_i
+        descriptive_teiv
         object_type_ssim
       </str>
       <str name="pf">
-        all_text_timv^10
+        descriptive_tiv^10
+        descriptive_text_nostem_i^5
+        descriptive_teiv^3
       </str>
 
       <str name="facet">true</str>
@@ -55,7 +59,7 @@
   </requestHandler>
 
   <!-- for relevancy experiments -->
-  <requestHandler name="/qttest" class="solr.SearchHandler">
+  <requestHandler name="qttest" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="defType">edismax</str>
       <str name="echoParams">explicit</str>
@@ -71,8 +75,6 @@
         sw_author_tesim^3
         topic_tesim^2
 
-        collection_title_tesim
-
         exploded_project_tag_ssim^2
         exploded_nonproject_tag_ssim
         exploded_tag_ssim
@@ -82,6 +84,12 @@
         sw_format_ssim
         object_type_ssim
 
+        descriptive_tiv
+        descriptive_text_nostem_i
+        descriptive_teiv
+
+        collection_title_tesim
+
         id
         objectId_tesim
         identifier_ssim
@@ -89,7 +97,8 @@
         barcode_id_ssim
         folio_instance_hrid_ssim
         source_id_ssim^3
-        source_id_text_nostem_i
+        source_id_ssi
+        source_id_text_nostem_i^3
         previous_ils_ids_ssim
         doi_ssim
         contributor_orcids_ssim
@@ -98,6 +107,10 @@
         sw_display_title_tesim^25
         sw_author_tesim^15
         topic_tesim^10
+
+        descriptive_tiv^5
+        descriptive_text_nostem_i^3
+        descriptive_teiv^2
 
         collection_title_tesim^5
 
@@ -110,6 +123,10 @@
         sw_author_tesim^9
         topic_tesim^6
 
+        descriptive_tiv^15
+        descriptive_text_nostem_i^9
+        descriptive_teiv^6
+
         collection_title_tesim^3
 
         objectId_tesim^3
@@ -120,6 +137,10 @@
         sw_display_title_tesim^10
         sw_author_tesim^6
         topic_tesim^4
+
+        descriptive_tiv^10
+        descriptive_text_nostem_i^6
+        descriptive_teiv^4
 
         collection_title_tesim^2
 

--- a/argo_qa/schema.xml
+++ b/argo_qa/schema.xml
@@ -11,9 +11,6 @@
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
-    <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
-    <field name="all_text_timv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
     <!-- string (_s...) -->
@@ -96,7 +93,7 @@
     <dynamicField name="*_bs"  type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true"  multiValued="false"/>
 
-      <!-- text (_t...) -->
+    <!-- text (_t...) -->
     <dynamicField name="*_ti"    type="text" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_tim"   type="text" stored="false" indexed="true"  multiValued="true"/>
     <dynamicField name="*_ts"    type="text" stored="true" indexed="false" multiValued="false"/>

--- a/argo_qa/solrconfig.xml
+++ b/argo_qa/solrconfig.xml
@@ -32,11 +32,15 @@
 
       <str name="qf">
         id
-        all_text_timv
+        descriptive_tiv
+        descriptive_text_nostem_i
+        descriptive_teiv
         object_type_ssim
       </str>
       <str name="pf">
-        all_text_timv^10
+        descriptive_tiv^10
+        descriptive_text_nostem_i^5
+        descriptive_teiv^3
       </str>
 
       <str name="facet">true</str>
@@ -55,7 +59,7 @@
   </requestHandler>
 
   <!-- for relevancy experiments -->
-  <requestHandler name="/qttest" class="solr.SearchHandler">
+  <requestHandler name="qttest" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="defType">edismax</str>
       <str name="echoParams">explicit</str>
@@ -71,8 +75,6 @@
         sw_author_tesim^3
         topic_tesim^2
 
-        collection_title_tesim
-
         exploded_project_tag_ssim^2
         exploded_nonproject_tag_ssim
         exploded_tag_ssim
@@ -82,6 +84,12 @@
         sw_format_ssim
         object_type_ssim
 
+        descriptive_tiv
+        descriptive_text_nostem_i
+        descriptive_teiv
+
+        collection_title_tesim
+
         id
         objectId_tesim
         identifier_ssim
@@ -89,7 +97,8 @@
         barcode_id_ssim
         folio_instance_hrid_ssim
         source_id_ssim^3
-        source_id_text_nostem_i
+        source_id_ssi
+        source_id_text_nostem_i^3
         previous_ils_ids_ssim
         doi_ssim
         contributor_orcids_ssim
@@ -98,6 +107,10 @@
         sw_display_title_tesim^25
         sw_author_tesim^15
         topic_tesim^10
+
+        descriptive_tiv^5
+        descriptive_text_nostem_i^3
+        descriptive_teiv^2
 
         collection_title_tesim^5
 
@@ -110,6 +123,10 @@
         sw_author_tesim^9
         topic_tesim^6
 
+        descriptive_tiv^15
+        descriptive_text_nostem_i^9
+        descriptive_teiv^6
+
         collection_title_tesim^3
 
         objectId_tesim^3
@@ -120,6 +137,10 @@
         sw_display_title_tesim^10
         sw_author_tesim^6
         topic_tesim^4
+
+        descriptive_tiv^10
+        descriptive_text_nostem_i^6
+        descriptive_teiv^4
 
         collection_title_tesim^2
 

--- a/argo_stage/schema.xml
+++ b/argo_stage/schema.xml
@@ -11,9 +11,6 @@
     <field name="_version_" type="long" indexed="true" stored="true" multiValued="false"/>
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 
-    <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
-    <field name="all_text_timv" type="text" stored="true" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
-
     <!-- NOTE:  not all possible Solr field types are represented in the dynamic fields -->
 
     <!-- string (_s...) -->
@@ -96,7 +93,7 @@
     <dynamicField name="*_bs"  type="boolean" stored="true" indexed="false" multiValued="false"/>
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true"  multiValued="false"/>
 
-      <!-- text (_t...) -->
+    <!-- text (_t...) -->
     <dynamicField name="*_ti"    type="text" stored="false" indexed="true"  multiValued="false"/>
     <dynamicField name="*_tim"   type="text" stored="false" indexed="true"  multiValued="true"/>
     <dynamicField name="*_ts"    type="text" stored="true" indexed="false" multiValued="false"/>

--- a/argo_stage/solrconfig.xml
+++ b/argo_stage/solrconfig.xml
@@ -32,11 +32,15 @@
 
       <str name="qf">
         id
-        all_text_timv
+        descriptive_tiv
+        descriptive_text_nostem_i
+        descriptive_teiv
         object_type_ssim
       </str>
       <str name="pf">
-        all_text_timv^10
+        descriptive_tiv^10
+        descriptive_text_nostem_i^5
+        descriptive_teiv^3
       </str>
 
       <str name="facet">true</str>
@@ -55,7 +59,7 @@
   </requestHandler>
 
   <!-- for relevancy experiments -->
-  <requestHandler name="/qttest" class="solr.SearchHandler">
+  <requestHandler name="qttest" class="solr.SearchHandler">
     <lst name="defaults">
       <str name="defType">edismax</str>
       <str name="echoParams">explicit</str>
@@ -71,8 +75,6 @@
         sw_author_tesim^3
         topic_tesim^2
 
-        collection_title_tesim
-
         exploded_project_tag_ssim^2
         exploded_nonproject_tag_ssim
         exploded_tag_ssim
@@ -82,6 +84,12 @@
         sw_format_ssim
         object_type_ssim
 
+        descriptive_tiv
+        descriptive_text_nostem_i
+        descriptive_teiv
+
+        collection_title_tesim
+
         id
         objectId_tesim
         identifier_ssim
@@ -89,7 +97,8 @@
         barcode_id_ssim
         folio_instance_hrid_ssim
         source_id_ssim^3
-        source_id_text_nostem_i
+        source_id_ssi
+        source_id_text_nostem_i^3
         previous_ils_ids_ssim
         doi_ssim
         contributor_orcids_ssim
@@ -98,6 +107,10 @@
         sw_display_title_tesim^25
         sw_author_tesim^15
         topic_tesim^10
+
+        descriptive_tiv^5
+        descriptive_text_nostem_i^3
+        descriptive_teiv^2
 
         collection_title_tesim^5
 
@@ -110,6 +123,10 @@
         sw_author_tesim^9
         topic_tesim^6
 
+        descriptive_tiv^15
+        descriptive_text_nostem_i^9
+        descriptive_teiv^6
+
         collection_title_tesim^3
 
         objectId_tesim^3
@@ -120,6 +137,10 @@
         sw_display_title_tesim^10
         sw_author_tesim^6
         topic_tesim^4
+
+        descriptive_tiv^10
+        descriptive_text_nostem_i^6
+        descriptive_teiv^4
 
         collection_title_tesim^2
 


### PR DESCRIPTION
Argo replaced its `all_text_timv` field with ... nothing ... some time ago.  We are now indexing to a "catch all text values" field, but it is now named `descriptive_xxx` and will allow us to phrase match and stuff.  sul-dlss/dor_indexing_app/pull/1037, which built on sul-dlss/dor_indexing_app/pull/1035

In addition, I did a little preparation for searching on tokens within source ids:  sul-dlss/argo/issues/4194

Testing:
- I will deploy the new configs to qa and stage and use Argo enough to be comfortable I didn't break anything before i deploy to prod.