### PR TITLE
Set id and barcode_search fields to string_punct_stop type

### DIFF
--- a/searchworks-prod-20230907/schema.xml
+++ b/searchworks-prod-20230907/schema.xml
@@ -7,7 +7,7 @@
     <!-- needed by some of Solr 4.0 functionality like transaction log or partial documents update -->
     <field name="_version_" type="long" indexed="true" stored="true" />
 
-    <field name="id" type="string" indexed="true" stored="true" required="true" docValues="true" />
+    <field name="id" type="string_punct_stop" indexed="true" stored="true" required="true" />
     <field name="timestamp" type="date" indexed="true" stored="true" default="NOW/SECOND" docValues="true" />
     <field name="created" type="date" indexed="true" stored="true" default="NOW/SECOND" docValues="true" />
     <field name="last_updated" type="date" indexed="true" stored="true" default="NOW/SECOND" docValues="true" />
@@ -196,7 +196,7 @@
     <field name="shelfkey" type="alphaSort" indexed="true" stored="true" multiValued="true" />
     <field name="reverse_shelfkey" type="alphaSort" indexed="true" stored="true" multiValued="true" />
 
-    <field name="barcode_search" type="string" indexed="true" stored="true" multiValued="true" docValues="true" />
+    <field name="barcode_search" type="string_punct_stop" indexed="true" stored="true" multiValued="true" />
     <field name="preferred_barcode" type="string" indexed="false" stored="true" />
     <field name="access_facet" type="string" indexed="true" stored="true" multiValued="true" docValues="true" />
     <field name="building_facet" type="string" indexed="true" stored="true" multiValued="true" />


### PR DESCRIPTION
@cbeer string_punct_stop is not compatible with docValues, but I have confirmed this change fixes our issue with searches containing a colon surrounded by spaces (https://jirasul.stanford.edu/jira/browse/SW-4213).