### PR TITLE
argo softCommit maxTime set to 5 seconds

### DIFF
--- a/argo_prod/solrconfig.xml
+++ b/argo_prod/solrconfig.xml
@@ -21,7 +21,7 @@
       <openSearcher>false</openSearcher>
     </autoCommit>
     <autoSoftCommit>
-      <maxTime>${solr.autoSoftCommit.maxTime:10000}</maxTime><!-- 10 seconds -->
+      <maxTime>${solr.autoSoftCommit.maxTime:5000}</maxTime><!-- 5 seconds -->
     </autoSoftCommit>
   </updateHandler>
 

--- a/argo_qa/solrconfig.xml
+++ b/argo_qa/solrconfig.xml
@@ -21,7 +21,7 @@
       <openSearcher>false</openSearcher>
     </autoCommit>
     <autoSoftCommit>
-      <maxTime>${solr.autoSoftCommit.maxTime:10000}</maxTime><!-- 10 seconds -->
+      <maxTime>${solr.autoSoftCommit.maxTime:5000}</maxTime><!-- 5 seconds -->
     </autoSoftCommit>
   </updateHandler>
 

--- a/argo_stage/solrconfig.xml
+++ b/argo_stage/solrconfig.xml
@@ -21,7 +21,7 @@
       <openSearcher>false</openSearcher>
     </autoCommit>
     <autoSoftCommit>
-      <maxTime>${solr.autoSoftCommit.maxTime:10000}</maxTime><!-- 10 seconds -->
+      <maxTime>${solr.autoSoftCommit.maxTime:5000}</maxTime><!-- 5 seconds -->
     </autoSoftCommit>
   </updateHandler>
 


### PR DESCRIPTION
Done to increase throughput of Argo's rolling reindexer.  This shaves a few days off it.