### PR TITLE
argo softCommit maxTime set to 1 minute

### DIFF
--- a/argo_prod/solrconfig.xml
+++ b/argo_prod/solrconfig.xml
@@ -21,7 +21,7 @@
       <openSearcher>false</openSearcher>
     </autoCommit>
     <autoSoftCommit>
-      <maxTime>${solr.autoSoftCommit.maxTime:5000}</maxTime><!-- 5 seconds -->
+      <maxTime>${solr.autoSoftCommit.maxTime:60000}</maxTime><!-- 1 minute -->
     </autoSoftCommit>
   </updateHandler>
 

--- a/argo_qa/solrconfig.xml
+++ b/argo_qa/solrconfig.xml
@@ -21,7 +21,7 @@
       <openSearcher>false</openSearcher>
     </autoCommit>
     <autoSoftCommit>
-      <maxTime>${solr.autoSoftCommit.maxTime:5000}</maxTime><!-- 5 seconds -->
+      <maxTime>${solr.autoSoftCommit.maxTime:60000}</maxTime><!-- 1 minute -->
     </autoSoftCommit>
   </updateHandler>
 

--- a/argo_stage/solrconfig.xml
+++ b/argo_stage/solrconfig.xml
@@ -21,7 +21,7 @@
       <openSearcher>false</openSearcher>
     </autoCommit>
     <autoSoftCommit>
-      <maxTime>${solr.autoSoftCommit.maxTime:5000}</maxTime><!-- 5 seconds -->
+      <maxTime>${solr.autoSoftCommit.maxTime:60000}</maxTime><!-- 1 minute -->
     </autoSoftCommit>
   </updateHandler>
 


### PR DESCRIPTION
Now that dor-indexing-app queries for ids in larger batches, we can set the softCommit to be significantly higher:  1 minute instead of 5 seconds.