### PR TITLE
Prevent Solr from treating standalone hyphens as query terms

### DIFF
--- a/searchworks-dev/schema.xml
+++ b/searchworks-dev/schema.xml
@@ -470,7 +470,7 @@
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
         <!-- put beginning and ending anchors on field value, removing trailing chars -->
         <!-- watch out for query time whitespace separated chars that will be processed as their own token stream, e.g. in 'felines : warm and fuzzy' -->
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*[\S&amp;&amp;[^\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]])[\s\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]*$" replacement="aaaaaa$1zzzzzz"/>
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*[\S&amp;&amp;[^\.\,\-:;/=&lt;&gt;\(\)\[\]\&amp;\|]])[\s\.\,\-:;/=&lt;&gt;\(\)\[\]\&amp;\|]*$" replacement="aaaaaa$1zzzzzz"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory" />
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
@@ -487,7 +487,7 @@
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
         <!-- put beginning and ending anchors on field value, removing trailing chars -->
         <!-- watch out for query time whitespace separated chars that will be processed as their own token stream, e.g. in 'felines : warm and fuzzy' -->
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*[\S&amp;&amp;[^\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]])[\s\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]*$" replacement="aaaaaa$1zzzzzz"/>
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*[\S&amp;&amp;[^\.\,\-:;/=&lt;&gt;\(\)\[\]\&amp;\|]])[\s\.\,\-:;/=&lt;&gt;\(\)\[\]\&amp;\|]*$" replacement="aaaaaa$1zzzzzz"/>
         <tokenizer class="solr.WhitespaceTokenizerFactory" />
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
@@ -527,7 +527,7 @@
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)\s+" replacement=" " />
         <!-- put beginning and ending anchors on field value, removing trailing chars -->
         <!-- watch out for query time whitespace separated chars that will be processed as their own token stream, e.g. in 'felines : warm and fuzzy' -->
-        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*[\S&amp;&amp;[^\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]])[\s\.\,:;/=&lt;&gt;\(\)\[\]\&amp;\|]*$" replacement="aaaaaa$1zzzzzz"/>
+        <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^\s*(.*[\S&amp;&amp;[^\.\,\-:;/=&lt;&gt;\(\)\[\]\&amp;\|]])[\s\.\,\-:;/=&lt;&gt;\(\)\[\]\&amp;\|]*$" replacement="aaaaaa$1zzzzzz"/>
         <charFilter class="edu.stanford.lucene.analysis.ICUCustomTransformCharFilterFactory" id="edu/stanford/lucene/analysis/stanford_cjk_transliterations.txt" />
         <charFilter class="edu.stanford.lucene.analysis.ICUTransformCharFilterFactory" id="Traditional-Simplified" />
         <charFilter class="edu.stanford.lucene.analysis.ICUTransformCharFilterFactory" id="Katakana-Hiragana" />

--- a/searchworks-dev/stopwords_punctuation.txt
+++ b/searchworks-dev/stopwords_punctuation.txt
@@ -2,7 +2,7 @@
 # by whitespace in a query, like 'fred : the puppy') in queries
 # ONLY FOR SINGLE TOKEN ANALYZED FIELDS
 #   see https://issues.apache.org/jira/browse/SOLR-3085
-# Note that hyphens, plusses, and double hyphens are not treated as terms
+# Note that plusses and double hyphens are not treated as terms
 #   per debugQuery
 :
 ;
@@ -20,3 +20,4 @@
 §
 •
 ·
+-


### PR DESCRIPTION
I'd like to test this potential fix for https://github.com/sul-dlss/searchworks_traject_indexer/issues/1309 on searchworks-stage. While the change includes index filters, I'm 75% sure the punctuation handling on the index side is no-op and shouldn't cause problems. The changes on the query side fix the problem without re-indexing in my testing locally.