### PR TITLE
argo solrconfig: replace objectId_tesim with druid_prefixed_ssi and druid_bare_ssi

### DIFF
--- a/argo_prod/solrconfig.xml
+++ b/argo_prod/solrconfig.xml
@@ -58,7 +58,8 @@
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim
@@ -81,7 +82,6 @@
 
         collection_title_tesim^5
 
-        objectId_tesim^5
         obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
@@ -97,7 +97,6 @@
 
         collection_title_tesim^3
 
-        objectId_tesim^3
         obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
@@ -113,7 +112,6 @@
 
         collection_title_tesim^2
 
-        objectId_tesim^2
         obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2
@@ -167,7 +165,8 @@
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim
@@ -190,7 +189,6 @@
 
         collection_title_tesim^5
 
-        objectId_tesim^5
         obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
@@ -206,7 +204,6 @@
 
         collection_title_tesim^3
 
-        objectId_tesim^3
         obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
@@ -222,7 +219,6 @@
 
         collection_title_tesim^2
 
-        objectId_tesim^2
         obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2

--- a/argo_qa/solrconfig.xml
+++ b/argo_qa/solrconfig.xml
@@ -58,7 +58,8 @@
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim
@@ -81,7 +82,6 @@
 
         collection_title_tesim^5
 
-        objectId_tesim^5
         obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
@@ -97,7 +97,6 @@
 
         collection_title_tesim^3
 
-        objectId_tesim^3
         obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
@@ -113,7 +112,6 @@
 
         collection_title_tesim^2
 
-        objectId_tesim^2
         obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2
@@ -167,7 +165,8 @@
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim
@@ -190,7 +189,6 @@
 
         collection_title_tesim^5
 
-        objectId_tesim^5
         obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
@@ -206,7 +204,6 @@
 
         collection_title_tesim^3
 
-        objectId_tesim^3
         obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
@@ -222,7 +219,6 @@
 
         collection_title_tesim^2
 
-        objectId_tesim^2
         obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2

--- a/argo_stage/solrconfig.xml
+++ b/argo_stage/solrconfig.xml
@@ -58,7 +58,8 @@
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim
@@ -81,7 +82,6 @@
 
         collection_title_tesim^5
 
-        objectId_tesim^5
         obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
@@ -97,7 +97,6 @@
 
         collection_title_tesim^3
 
-        objectId_tesim^3
         obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
@@ -113,7 +112,6 @@
 
         collection_title_tesim^2
 
-        objectId_tesim^2
         obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2
@@ -167,7 +165,8 @@
         collection_title_tesim
 
         id
-        objectId_tesim
+        druid_bare_ssi
+        druid_prefixed_ssi
         obj_label_tesim
         identifier_ssim
         identifier_tesim
@@ -190,7 +189,6 @@
 
         collection_title_tesim^5
 
-        objectId_tesim^5
         obj_label_tesim^5
         identifier_tesim^5
         source_id_text_nostem_i^5
@@ -206,7 +204,6 @@
 
         collection_title_tesim^3
 
-        objectId_tesim^3
         obj_label_tesim^3
         identifier_tesim^3
         source_id_text_nostem_i^3
@@ -222,7 +219,6 @@
 
         collection_title_tesim^2
 
-        objectId_tesim^2
         obj_label_tesim^2
         identifier_tesim^2
         source_id_text_nostem_i^2


### PR DESCRIPTION
Part of https://github.com/sul-dlss/dor_indexing_app/issues/1031

This change is to search the newly populated fields `druid_prefixed_ssi` and `druid_bare_ssi` instead of the old `objectId_tesim` which had both a poor name and a poor type.

Since the druids are used as strings in searching, there is no need to boost in a phrase or n-gram match -- there is only one token.

I tested this change by applying the new solrconfig to argo_qa and searching on bare druid and on prefixed druid, and it worked exactly as it does it prod.

My confidence is SO HIGH that I actually applied these solrconfigs in argo stage AND prod already.  Shhhhhh.

(actually, the real solr fields searched are in the argo code.  See sul-dlss/argo/pull/4328