### PR TITLE
argo_xx: boost primary author over other contributors in search results

### DIFF
--- a/argo_prod/solrconfig.xml
+++ b/argo_prod/solrconfig.xml
@@ -46,7 +46,9 @@
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im
@@ -87,7 +89,9 @@
         additional_titles_unstemmed_im^25
         additional_titles_tenim^15
 
-        contributor_text_nostem_im^15
+        author_text_nostem_im^15
+        contributor_text_nostem_im^5
+
         topic_tesim^10
 
         descriptive_text_nostem_i^5
@@ -109,7 +113,9 @@
         additional_titles_unstemmed_im^15
         additional_titles_tenim^9
 
-        contributor_text_nostem_im^9
+        author_text_nostem_im^9
+        contributor_text_nostem_im^3
+
         topic_tesim^6
 
         descriptive_text_nostem_i^15
@@ -131,7 +137,9 @@
         additional_titles_unstemmed_im^10
         additional_titles_tenim^6
 
-        contributor_text_nostem_im^6
+        author_text_nostem_im^6
+        contributor_text_nostem_im^2
+
         topic_tesim^4
 
         descriptive_text_nostem_i^10
@@ -181,7 +189,9 @@
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im
@@ -222,7 +232,9 @@
         additional_titles_unstemmed_im^25
         additional_titles_tenim^15
 
-        contributor_text_nostem_im^15
+        author_text_nostem_im^15
+        contributor_text_nostem_im^5
+
         topic_tesim^10
 
         descriptive_text_nostem_i^5
@@ -244,7 +256,9 @@
         additional_titles_unstemmed_im^15
         additional_titles_tenim^9
 
-        contributor_text_nostem_im^9
+        author_text_nostem_im^9
+        contributor_text_nostem_im^3
+
         topic_tesim^6
 
         descriptive_text_nostem_i^15
@@ -266,7 +280,9 @@
         additional_titles_unstemmed_im^10
         additional_titles_tenim^6
 
-        contributor_text_nostem_im^6
+        author_text_nostem_im^6
+        contributor_text_nostem_im^2
+
         topic_tesim^4
 
         descriptive_text_nostem_i^10

--- a/argo_qa/solrconfig.xml
+++ b/argo_qa/solrconfig.xml
@@ -46,7 +46,9 @@
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im
@@ -87,7 +89,9 @@
         additional_titles_unstemmed_im^25
         additional_titles_tenim^15
 
-        contributor_text_nostem_im^15
+        author_text_nostem_im^15
+        contributor_text_nostem_im^5
+
         topic_tesim^10
 
         descriptive_text_nostem_i^5
@@ -109,7 +113,9 @@
         additional_titles_unstemmed_im^15
         additional_titles_tenim^9
 
-        contributor_text_nostem_im^9
+        author_text_nostem_im^9
+        contributor_text_nostem_im^3
+
         topic_tesim^6
 
         descriptive_text_nostem_i^15
@@ -131,7 +137,9 @@
         additional_titles_unstemmed_im^10
         additional_titles_tenim^6
 
-        contributor_text_nostem_im^6
+        author_text_nostem_im^6
+        contributor_text_nostem_im^2
+
         topic_tesim^4
 
         descriptive_text_nostem_i^10
@@ -181,7 +189,9 @@
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im
@@ -222,7 +232,9 @@
         additional_titles_unstemmed_im^25
         additional_titles_tenim^15
 
-        contributor_text_nostem_im^15
+        author_text_nostem_im^15
+        contributor_text_nostem_im^5
+
         topic_tesim^10
 
         descriptive_text_nostem_i^5
@@ -244,7 +256,9 @@
         additional_titles_unstemmed_im^15
         additional_titles_tenim^9
 
-        contributor_text_nostem_im^9
+        author_text_nostem_im^9
+        contributor_text_nostem_im^3
+
         topic_tesim^6
 
         descriptive_text_nostem_i^15
@@ -266,7 +280,9 @@
         additional_titles_unstemmed_im^10
         additional_titles_tenim^6
 
-        contributor_text_nostem_im^6
+        author_text_nostem_im^6
+        contributor_text_nostem_im^2
+
         topic_tesim^4
 
         descriptive_text_nostem_i^10

--- a/argo_stage/solrconfig.xml
+++ b/argo_stage/solrconfig.xml
@@ -46,7 +46,9 @@
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im
@@ -87,7 +89,9 @@
         additional_titles_unstemmed_im^25
         additional_titles_tenim^15
 
-        contributor_text_nostem_im^15
+        author_text_nostem_im^15
+        contributor_text_nostem_im^5
+
         topic_tesim^10
 
         descriptive_text_nostem_i^5
@@ -109,7 +113,9 @@
         additional_titles_unstemmed_im^15
         additional_titles_tenim^9
 
-        contributor_text_nostem_im^9
+        author_text_nostem_im^9
+        contributor_text_nostem_im^3
+
         topic_tesim^6
 
         descriptive_text_nostem_i^15
@@ -131,7 +137,9 @@
         additional_titles_unstemmed_im^10
         additional_titles_tenim^6
 
-        contributor_text_nostem_im^6
+        author_text_nostem_im^6
+        contributor_text_nostem_im^2
+
         topic_tesim^4
 
         descriptive_text_nostem_i^10
@@ -181,7 +189,9 @@
         additional_titles_unstemmed_im^5
         additional_titles_tenim^3
 
-        contributor_text_nostem_im^3
+        author_text_nostem_im^3
+        contributor_text_nostem_im
+
         topic_tesim^2
 
         tag_text_unstemmed_im
@@ -222,7 +232,9 @@
         additional_titles_unstemmed_im^25
         additional_titles_tenim^15
 
-        contributor_text_nostem_im^15
+        author_text_nostem_im^15
+        contributor_text_nostem_im^5
+
         topic_tesim^10
 
         descriptive_text_nostem_i^5
@@ -244,7 +256,9 @@
         additional_titles_unstemmed_im^15
         additional_titles_tenim^9
 
-        contributor_text_nostem_im^9
+        author_text_nostem_im^9
+        contributor_text_nostem_im^3
+
         topic_tesim^6
 
         descriptive_text_nostem_i^15
@@ -266,7 +280,9 @@
         additional_titles_unstemmed_im^10
         additional_titles_tenim^6
 
-        contributor_text_nostem_im^6
+        author_text_nostem_im^6
+        contributor_text_nostem_im^2
+
         topic_tesim^4
 
         descriptive_text_nostem_i^10


### PR DESCRIPTION
~~hold for testing;  also hold for #309~~

part of sul-dlss/argo/issues/4329

This is desired for better Argo search results ... which now default to ordered by relevancy, not druid!

Andrew and I vetted this.