### PR TITLE
Remove unused (and deprecated) fields + field types

### DIFF
--- a/cidr-authorial-prod/schema.xml
+++ b/cidr-authorial-prod/schema.xml
@@ -93,8 +93,6 @@
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
-    <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
   </types>
   <fields>
     <!-- Valid attributes for fields:
@@ -245,12 +243,6 @@
 
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
     <dynamicField name="*_coordinate"  type="tdouble" indexed="true"  stored="true"  multiValued="false"/>
-    <dynamicField name="*_p" type="location" indexed="true" stored="true" multiValued="false"/>
-
-    <dynamicField name="*_ll" stored="true"  type="location" multiValued="false" indexed="true"/>
-    <dynamicField name="*_llm" stored="true"  type="location" multiValued="true" indexed="true"/>
-    <dynamicField name="*_lls" stored="true" type="location" multiValued="false" indexed="true"/>
-    <dynamicField name="*_llms" stored="true" type="location" multiValued="true" indexed="true"/>
     <field name="textSpell" stored="false"  type="textSpell" multiValued="true" indexed="true"/>
 
     <!-- required by Solr 4 -->

--- a/cidr-dig-hcrc-prod/schema.xml
+++ b/cidr-dig-hcrc-prod/schema.xml
@@ -132,7 +132,6 @@ both match, the first appearing in the schema will be used. -->
     <dynamicField name="*_coordinate" type="tdouble" indexed="true" stored="true"/>
 
     <dynamicField name="*_dt" type="date" indexed="true" stored="true"/>
-    <dynamicField name="*_p" type="location" indexed="true" stored="true"/>
 
     <!-- some trie-coded dynamic fields for faster range queries -->
     <dynamicField name="*_ti" type="tint" indexed="true" stored="true"/>
@@ -702,9 +701,6 @@ or to add multiple fields to the same field for easier/faster searching. -->
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-
-    <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
 
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:

--- a/earthworks-prod/schema.xml
+++ b/earthworks-prod/schema.xml
@@ -62,7 +62,6 @@
              as WKT for point, linestring, polygon
 
       -->
-    <dynamicField name="*_pt"   type="location"     stored="true" indexed="true"/>
     <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/><!-- deprecated -->
     <dynamicField name="*_geom" type="location_rpt" stored="true" indexed="true"/>
     <!-- <dynamicField name="*_jts"  type="location_jts" stored="true" indexed="true"/> -->
@@ -132,9 +131,6 @@
         <filter class="solr.LengthFilterFactory" min="2" max="255"/>
       </analyzer>
     </fieldType>
-
-    <!-- Spatial field types -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_d"/>
 
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                distErrPct="0.025"

--- a/earthworks-stage/schema.xml
+++ b/earthworks-stage/schema.xml
@@ -62,7 +62,6 @@
              as WKT for point, linestring, polygon
 
       -->
-    <dynamicField name="*_pt"   type="location"     stored="true" indexed="true"/>
     <dynamicField name="*_bbox" type="location_rpt" stored="true" indexed="true"/><!-- deprecated -->
     <dynamicField name="*_geom" type="location_rpt" stored="true" indexed="true"/>
     <!-- <dynamicField name="*_jts"  type="location_jts" stored="true" indexed="true"/> -->
@@ -134,8 +133,6 @@
     </fieldType>
 
     <!-- Spatial field types -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_d"/>
-
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                distErrPct="0.025"
                maxDistErr="0.000009"

--- a/exhibits/schema.xml
+++ b/exhibits/schema.xml
@@ -258,10 +258,8 @@
     <dynamicField name="*_tesimv" type="text" stored="true" indexed="true" multiValued="true" storeOffsetsWithPositions="true" termVectors="true" />
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_ng" type="text_en_ng" stored="false" indexed="true" multiValued="true"/>
-    <dynamicField name="*_pt" type="location" stored="true" indexed="true"/>
     <dynamicField name="*_bbox" type="bbox" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_srpt" type="location_rpt" stored="true" indexed="true" multiValued="true"/>
-    <dynamicField name="*_geohash" type="geohash" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_ts" type="text" indexed="false" stored="true" multiValued="false" />
     <dynamicField name="random*" type="random" />
   </fields>
@@ -612,14 +610,6 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-
-    <!-- A Geohash is a compact representation of a latitude longitude pair in a single field.
-      See http://wiki.apache.org/solr/SpatialSearch
-    -->
-    <fieldtype name="geohash" class="solr.GeoHashField"/>
-
-    <!-- A specialized field for geospatial search. If indexed, fields of this type must NOT be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
 
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:

--- a/exhibits_stage/schema.xml
+++ b/exhibits_stage/schema.xml
@@ -258,10 +258,8 @@
     <dynamicField name="*_tesimv" type="text" stored="true" indexed="true" multiValued="true" storeOffsetsWithPositions="true" termVectors="true" />
     <dynamicField name="*_bsi" type="boolean" stored="true" indexed="true" multiValued="true" omitNorms="true" />
     <dynamicField name="*_ng" type="text_en_ng" stored="false" indexed="true" multiValued="true"/>
-    <dynamicField name="*_pt" type="location" stored="true" indexed="true"/>
     <dynamicField name="*_bbox" type="bbox" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_srpt" type="location_rpt" stored="true" indexed="true" multiValued="true"/>
-    <dynamicField name="*_geohash" type="geohash" stored="true" indexed="true" multiValued="true"/>
     <dynamicField name="*_ts" type="text" indexed="false" stored="true" multiValued="false" />
     <dynamicField name="random*" type="random" />
   </fields>
@@ -596,14 +594,6 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-
-    <!-- A Geohash is a compact representation of a latitude longitude pair in a single field.
-      See http://wiki.apache.org/solr/SpatialSearch
-    -->
-    <fieldtype name="geohash" class="solr.GeoHashField"/>
-
-    <!-- A specialized field for geospatial search. If indexed, fields of this type must NOT be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
 
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:


### PR DESCRIPTION
I don't see any indication any of these apps index into or query against these location fields, and `LatLonType` is deprecated and removed in Solr 9.

@thatbudakguy confirmed Earthworks only uses the `*_geom` type, which seems like the only app that would likely use that geospatial data anyway 🤷‍♂️  