### PR TITLE
Remove the healthcheckFile option from Earthworks core ping handlers

### DIFF
--- a/earthworks-aardvark-prod/solrconfig.xml
+++ b/earthworks-aardvark-prod/solrconfig.xml
@@ -172,12 +172,6 @@
     <lst name="defaults">
       <str name="echoParams">all</str>
     </lst>
-    <!-- An optional feature of the PingRequestHandler is to configure the
-         handler with a "healthcheckFile" which can be used to enable/disable
-         the PingRequestHandler.
-         relative paths are resolved against the data dir
-      -->
-    <str name="healthcheckFile">server-enabled.txt</str>
   </requestHandler>
 
   <requestHandler name="/analysis/field"

--- a/earthworks-aardvark-stage/solrconfig.xml
+++ b/earthworks-aardvark-stage/solrconfig.xml
@@ -172,12 +172,6 @@
     <lst name="defaults">
       <str name="echoParams">all</str>
     </lst>
-    <!-- An optional feature of the PingRequestHandler is to configure the
-         handler with a "healthcheckFile" which can be used to enable/disable
-         the PingRequestHandler.
-         relative paths are resolved against the data dir
-      -->
-    <str name="healthcheckFile">server-enabled.txt</str>
   </requestHandler>
 
   <requestHandler name="/analysis/field"


### PR DESCRIPTION
The lack of this file was causing ping checks to fail and the
cores to appear to be unhealthy/offline.
