### PR TITLE
Simplify the list of initial query fields for searchworks

### DIFF
--- a/searchworks-gryphon-search/solrconfig.xml
+++ b/searchworks-gryphon-search/solrconfig.xml
@@ -258,6 +258,31 @@
       <str name="qf">
         title_245a_exact_search^1000
         title_245a_unstem_search^500
+        title_245_unstem_search^75
+        title_245_search^50            vern_title_245_search^50
+
+        author_title_1xx_unstem_search^250
+        author_title_245ac_unstem_search^100
+        author_title_1xx_search^50
+        author_title_unstem_search^25
+        author_title_search^10
+
+        topic_unstem_search^50
+        topic_search^20
+        db_az_subject_search^5
+
+        pub_date_search^2
+        isbn_search^1.6
+        issn_search^1.6
+        id_search
+        druid
+        item_barcodes_search
+        all_search                     vern_all_search
+      </str>
+
+      <str name="qf_single_term">
+        title_245a_exact_search^1000
+        title_245a_unstem_search^500
         title_245a_search^75           vern_title_245a_search^75
         title_245_unstem_search^75
         title_245_search^50            vern_title_245_search^50

--- a/searchworks-gryphon-search/solrconfig.xml
+++ b/searchworks-gryphon-search/solrconfig.xml
@@ -253,7 +253,7 @@
       <!-- in case lucene query parser -->
       <str name="df">all_search</str>
       <str name="q.op">AND</str>
-      <str name="sow">false</str>
+      <str name="sow">true</str>
 
       <str name="qf">
         title_245a_exact_search^1000


### PR DESCRIPTION
For single-term queries (with https://github.com/sul-dlss/SearchWorks/pull/4356), the relevancy ranking is unchanged.

For multi-term queries, my theory is the boosts from `pf2`, `pf3`, and `pf` are more than enough to ensure appropriate relevancy and that we don't need to include every field in the `qf`. This should result in faster query times (and allowing us to lower the max boolean clauses limit in Solr 9 (and hopefully make solr more stable...))

The simplified `qf` will also make it easier to tweak relevancy when we go to disable `sow`.