### PR TITLE
Add callnum_search to searchworks-prod

### DIFF
--- a/searchworks-prod-20230907/solrconfig.xml
+++ b/searchworks-prod-20230907/solrconfig.xml
@@ -284,6 +284,7 @@
         isbn_search^1.6
         issn_search^1.6
         id_search
+        callnum_search
         druid
         oclc
         item_barcodes_search
@@ -355,6 +356,7 @@
         pub_date_search^2
         isbn_search^1.6
         issn_search^1.6
+        callnum_search
         id_search
         druid
         oclc
@@ -426,6 +428,7 @@
         bib_search^7
         pub_date_search^10
         issn_search^7.5
+        callnum_search^7
         physical^5                     vern_physical^5
         award_search^5
         collection_search^5


### PR DESCRIPTION
Closes https://github.com/sul-dlss/searchworks_traject_indexer/issues/1591

https://github.com/sul-dlss/SearchWorks/pull/5013

We've already added this to searchworks-gryphon-search. The other SearchWorks environments have `<str name="sow">true</str>` and we should not add `callnum_search` in those situations. The fieldType's analyzer expects the unsplit term.