### PR TITLE
adding edge ngram to suggest indexing

### DIFF
--- a/searchworks-gryphon-search/schema.xml
+++ b/searchworks-gryphon-search/schema.xml
@@ -665,8 +665,14 @@
 
     <!-- for suggestions -->
     <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer class="solr.KeywordTokenizerFactory"/>
+      <analyzer type="index">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="10"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>


### PR DESCRIPTION
These updates are to help with testing author autocomplete.

We want to support matching the beginning part of any of the words in an author/contributor name. 

- Changing query and index analyzers to StandardTokenizer from KeywordTokenizer means the input/matching strings can separate tokens based on whitespace and punctuation. This means that indexing and query can regard multiple words separately, which is useful for matching more than just the beginning of the string in the suggest field.
- Using an EdgeNGramFilterFactory for indexing allows for matching against the beginning of any of the words in a multi-word/token phrase. EdgeNGramFilterFactory creates n-grams from the beginning of the word.