### PR TITLE
updating autosuggest configuration

### DIFF
--- a/searchworks-gryphon-search/schema.xml
+++ b/searchworks-gryphon-search/schema.xml
@@ -664,8 +664,14 @@
       </analyzer>
     </fieldType>
 
-    <!-- for suggestions -->
-    <fieldType class="solr.TextField" name="textSuggest" positionIncrementGap="100">
+    <!-- for storing suggestions -->
+    <fieldType name="textSuggest" class="solr.TextField" positionIncrementGap="100">
+        <tokenizer class="solr.KeywordTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+        <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
+    </fieldType>
+    <!-- for analysis of suggested text as part of lookup implementation-->
+    <fieldType name="textSuggestAnalyzer" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>

--- a/searchworks-gryphon-search/solrconfig.xml
+++ b/searchworks-gryphon-search/solrconfig.xml
@@ -1210,26 +1210,11 @@
       <str name="buildOnCommit">true</str>
       <str name="field">suggest</str>
     </lst>
-     <lst name="suggester">
-      <str name="name">mySuggesterPrefix</str>
-      <str name="lookupImpl">FuzzyLookupFactory</str>
-      <str name="nonFuzzyPrefix">3</str>
-      <str name="suggestAnalyzerFieldType">textSuggest</str>
-      <str name="buildOnCommit">true</str>
-      <str name="field">suggest</str>
-    </lst>
     <lst name="suggester">
       <str name="name">defaultAnalyzing</str>
       <str name="lookupImpl">AnalyzingInfixLookupFactory</str>
-      <str name="suggestAnalyzerFieldType">textSuggest</str>
-      <str name="buildOnCommit">true</str>
-      <str name="field">suggest</str>
-    </lst>
-    <lst name="suggester">
-      <str name="name">defaultBlended</str>
-      <str name="lookupImpl">BlendedInfixLookupFactory</str>
-      <str name="suggestAnalyzerFieldType">textSuggest</str>
-      <str name="buildOnCommit">true</str>
+      <str name="suggestAnalyzerFieldType">textSuggestAnalyzer</str>
+      <str name="buildOnCommit">false</str>
       <str name="field">suggest</str>
     </lst>
   </searchComponent>


### PR DESCRIPTION
For SearchWorks Gryphon Search autosuggest testing.

What this PR does:
- Separates the field type for allowing n-gram matching as part of the analyzer in the lookup implementation from the field type for storing the author facet values.  The former maintains its query and index time analysis allowing for breaking up tokens/matching the beginning of words.  The latter stores the string as is without much tokenization (using the KeywordTokenizer).
- Also updated the suggest configuration to not build on commits.  Builds will have to be conducted manually - although after testing, we may change our minds.