### PR TITLE
saving the suggest field for debugging

### DIFF
--- a/searchworks-gryphon-search/schema.xml
+++ b/searchworks-gryphon-search/schema.xml
@@ -297,7 +297,7 @@
     <dynamicField name="*_hsim" type="string_hierarch" stored="true" indexed="true" multiValued="true" />
     <dynamicField name="*_struct" type="string" stored="true" indexed="false" multiValued="true" omitNorms="true" />
     <dynamicField name="*_dtsi" type="date" stored="true" indexed="false" omitNorms="true" />
-    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
+    <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="true" multiValued="true" />
   </fields>
 
   <!-- copy fields -->


### PR DESCRIPTION
This PR saves/stores the suggest field.  Storing the suggest field is recommended in any case, but we are doing this primarily to debug/see what values end up in the suggest field