### PR TITLE
making autocomplete dictionary default, increasing max ngram

### DIFF
--- a/searchworks-gryphon-search/schema.xml
+++ b/searchworks-gryphon-search/schema.xml
@@ -676,7 +676,7 @@
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
-        <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="10"/>
+        <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="20"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>

--- a/searchworks-gryphon-search/solrconfig.xml
+++ b/searchworks-gryphon-search/solrconfig.xml
@@ -1205,13 +1205,6 @@
   <searchComponent name="suggest" class="solr.SuggestComponent">
     <lst name="suggester">
       <str name="name">mySuggester</str>
-      <str name="lookupImpl">FuzzyLookupFactory</str>
-      <str name="suggestAnalyzerFieldType">textSuggest</str>
-      <str name="buildOnCommit">true</str>
-      <str name="field">suggest</str>
-    </lst>
-    <lst name="suggester">
-      <str name="name">defaultAnalyzing</str>
       <str name="lookupImpl">AnalyzingInfixLookupFactory</str>
       <str name="suggestAnalyzerFieldType">textSuggestAnalyzer</str>
       <str name="buildOnCommit">false</str>


### PR DESCRIPTION
Relates to SearchWorks author autocomplete.

What this PR does:
- Make the default mySuggester search dictionary have the settings we have tried out and approve for autocomplete
- Increase the max ngram size to 20