### PR TITLE
Copying specific _s fields instead of all of them for text search

### DIFF
--- a/earthworks-aardvark-stage/schema.xml
+++ b/earthworks-aardvark-stage/schema.xml
@@ -167,7 +167,11 @@
   <copyField source="id"       dest="layer_slug_ti"       maxChars="100"/>
 
   <!-- core text search -->
-  <copyField source="*_s"                dest="text" />
+  <copyField source="dct_accessRights_s"               dest="text" />
+  <copyField source="dct_format_s"                     dest="text" />
+  <copyField source="dct_issued_s"                     dest="text" />
+  <copyField source="dct_title_s"                      dest="text" />
+  <copyField source="gbl_wxsIdentifier_s"              dest="text" />
   <copyField source="*_sm"               dest="text" />
 
   <!-- for sorting text fields -->

--- a/earthworks-aardvark-stage/schema.xml
+++ b/earthworks-aardvark-stage/schema.xml
@@ -167,7 +167,6 @@
   <copyField source="id"       dest="layer_slug_ti"       maxChars="100"/>
 
   <!-- core text search -->
-  <copyField source="dct_accessRights_s"               dest="text" />
   <copyField source="dct_format_s"                     dest="text" />
   <copyField source="dct_issued_s"                     dest="text" />
   <copyField source="dct_title_s"                      dest="text" />


### PR DESCRIPTION
Addresses https://github.com/sul-dlss/earthworks/issues/1513 .

Instead of copying the dynamic field *_s to the text search field, we're copying over specific fields of interest as identified in the ticket, thus preventing the tokenization and indexing of the dct_references_s field which was leading to incorrect/unanticipated search results.