### PR TITLE
Dwexp-demo updates: Solr schema updates for fielded boosting and fielded search

### DIFF
--- a/dwexp-demo/schema.xml
+++ b/dwexp-demo/schema.xml
@@ -194,7 +194,7 @@
     <dynamicField name="*suggest" type="textSuggest" indexed="true" stored="false" multiValued="true" />
 
     <!-- you must define copyField source and dest fields explicity or schemaBrowser doesn't work -->
-    <field name="all_text_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
+    <field name="all_text" type="text_en" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
 
 
   </fields>
@@ -205,10 +205,10 @@
       destination field is to use the dynamic field syntax.
       copyField also supports a maxChars to copy setting.  -->
 
-  <copyField source="*_tsim" dest="all_text_timv" maxChars="3000"/>
-  <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/>
-  <copyField source="*_ssim" dest="all_text_timv" maxChars="3000"/>
-  <copyField source="*_si" dest="all_text_timv" maxChars="3000"/>
+  <copyField source="*_tsim" dest="all_text" maxChars="3000"/>
+  <copyField source="*_tesim" dest="all_text" maxChars="3000"/>
+  <copyField source="*_ssim" dest="all_text" maxChars="3000"/>
+  <copyField source="*_si" dest="all_text" maxChars="3000"/>
 
   <copyField source="*_tsim" dest="suggest"/>
   <copyField source="*_tesim" dest="suggest"/>

--- a/dwexp-demo/solrconfig.xml
+++ b/dwexp-demo/solrconfig.xml
@@ -62,7 +62,7 @@
           variables_tsim^600
           temporal_isim^500
           id
-          all_text_timv
+          all_text
         </str>
         <!-- Boosting document scores based on query phrases in fields-->
         <str name="pf">
@@ -81,7 +81,7 @@
           publisher_tsi^700
           variables_tsim^600
           temporal_isim^500
-          all_text_timv
+          all_text
         </str>
        <str name="author_qf">
           creators_tsim


### PR DESCRIPTION
Closes https://github.com/sul-dlss/dataworks-etl/issues/321 

What this PR does:

a) Specify boost levels for query fields and phrase boosting in solr configuration, with titles being boosted most, followed by various kinds of descriptions, creator and contributor names, subjects, funder names, publisher names, variables, and temporal dates.  The catch all "all_text_timv" field is kept at the end to allow for broad search matching.
b) Copy specific _ssim fields used to _tsim fields so we can use them in the query fields above.  
c) Update the fielded search to use _tsim fields (except for DOI which can remain as a string)
d) Copy the appropriate fields over to the spellcheck fields, for use later if we choose to test this feature out.
e) Update the qs and ps values to mirror those in other systems like SearchWorks or DataWorks.
f) Changes all_text_timv to not use the dynamic field ending and be of type text_en to support additional. We may need to revisit if we get a lot of multilingual content later, but for now, this should support better stemming.