### PR TITLE
Change `text_en` type to use whitespace tokenization instead of ICU

### DIFF
--- a/argo_stage/schema.xml
+++ b/argo_stage/schema.xml
@@ -35,7 +35,7 @@
     <dynamicField name="*_ipsi"   type="intPoint" stored="true"  indexed="true"  multiValued="false"/>
     <dynamicField name="*_ipsidv" type="intPoint" stored="true"  indexed="true"  multiValued="false" docValues="true"/>
     <dynamicField name="*_ipsim"  type="intPoint" stored="true"  indexed="true"  multiValued="true"/>
-    
+
     <!-- Long field (_lp...) (64-bit signed integer). (very efficient searches for specific values, or ranges of values.) -->
     <!-- For single valued fields, docValues="true" must be used to enable sorting. -->
     <dynamicField name="*_lpi"    type="longPoint" stored="false" indexed="true"  multiValued="false" docValues="true"/>
@@ -307,7 +307,7 @@
     <!-- DEPRECATED:  use textEnglish, as more aggressive stemming desired.  A text field with defaults appropriate for English -->
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer>
-        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.EnglishPossessiveFilterFactory"/>
         <!-- EnglishMinimalStemFilterFactory is less aggressive than PorterStemFilterFactory: -->


### PR DESCRIPTION
Because apparently the ICU tokenizer changed in Solr 9.7.0 such that strings like `druid:bc123df4567` are split on the colon character which causes unexpected results, namely if you do a full search for a specific druid, you get many hits because some *_te* fields will now match the split druid. This change is for testing in the argo-stage environment.
