### PR TITLE
Remove locally set max boolean clause limit

### DIFF
--- a/earthworks-aardvark-stage/solrconfig.xml
+++ b/earthworks-aardvark-stage/solrconfig.xml
@@ -63,7 +63,6 @@
        Query section - these settings control query time things like caches
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
   <query>
-    <maxBooleanClauses>1024</maxBooleanClauses>
     <filterCache class="solr.search.CaffeineCache" size="512" initialSize="512" autowarmCount="0" />
     <queryResultCache class="solr.search.CaffeineCache" size="512" initialSize="512" autowarmCount="0"/>
     <documentCache class="solr.search.CaffeineCache" size="512" initialSize="512" autowarmCount="0"/>


### PR DESCRIPTION
This is set globally in puppet to `16374` so let's not set it locally.

Might addresses https://github.com/sul-dlss/earthworks/issues/1589