### PR TITLE
Remove locally set max boolean clause limit

### DIFF
--- a/earthworks-aardvark-prod/solrconfig.xml
+++ b/earthworks-aardvark-prod/solrconfig.xml
@@ -63,7 +63,6 @@
        Query section - these settings control query time things like caches
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
   <query>
-    <maxBooleanClauses>1024</maxBooleanClauses>
     <filterCache class="solr.search.CaffeineCache" size="512" initialSize="512" autowarmCount="0" />
     <queryResultCache class="solr.search.CaffeineCache" size="512" initialSize="512" autowarmCount="0"/>
     <documentCache class="solr.search.CaffeineCache" size="512" initialSize="512" autowarmCount="0"/>


### PR DESCRIPTION
The globally set max.booleanClauses (via puppet) takes precedence, but let's remove this anyway to avoid confusion. Related to https://github.com/sul-dlss/earthworks/issues/1589