### PR TITLE
use filters before synonyms to reduce complexity

### DIFF
--- a/earthworks-aardvark-stage/schema.xml
+++ b/earthworks-aardvark-stage/schema.xml
@@ -96,10 +96,10 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
     </fieldType>


### PR DESCRIPTION
Will help standardize some terms before we look for synonyms, enabling us to remove some options currently encoded in the synonym file and/or streamline in general.  This new approach will remove stop words before looking for synonyms so we will need to take that into account in the synonyms file

Helps address https://github.com/sul-dlss/earthworks/issues/1589