### PR TITLE
Add uninvertable attribute to text_sort fieldType

### DIFF
--- a/earthworks-aardvark-stage/schema.xml
+++ b/earthworks-aardvark-stage/schema.xml
@@ -105,7 +105,7 @@
     </fieldType>
 
     <!-- for alpha sorting as a single token -->
-    <fieldType name="text_sort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
+    <fieldType name="text_sort" class="solr.TextField" sortMissingLast="true" omitNorms="true" uninvertable="true">
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
         <filter class="solr.LowerCaseFilterFactory" />


### PR DESCRIPTION
See https://github.com/sul-dlss/earthworks/pull/1642

Fixes an error:
```
org.apache.solr.common.SolrException: can not sort on a field w/o docValues unless it is indexed=true uninvertible=true and the type supports Uninversion: dct_title_sort
```